### PR TITLE
yq: Fix path resolution for external targets

### DIFF
--- a/lib/private/yq.bzl
+++ b/lib/private/yq.bzl
@@ -71,10 +71,13 @@ def _yq_impl(ctx):
 
     # For split operations, yq outputs files in the same directory so we
     # must cd to the correct output dir before executing it
-    bin_dir = "/".join([ctx.bin_dir.path, ctx.label.package]) if ctx.label.package else ctx.bin_dir.path
+    bin_dir = ctx.bin_dir.path
+    if ctx.label.workspace_name:
+        bin_dir = "%s/external/%s" % (bin_dir, ctx.label.workspace_name)
+    bin_dir = "/".join([bin_dir, ctx.label.package]) if ctx.label.package else bin_dir
     escape_bin_dir = _escape_path(bin_dir)
     cmd = "cd {bin_dir} && {yq} {args} {eval_cmd} {expression} {sources} {maybe_out}".format(
-        bin_dir = ctx.bin_dir.path + "/" + ctx.label.package,
+        bin_dir = bin_dir,
         yq = escape_bin_dir + yq_bin.path,
         eval_cmd = "eval" if len(inputs) <= 1 else "eval-all",
         args = " ".join(args),


### PR DESCRIPTION
Currently the `yq` target is unusable if called from an external build, this should resolve that

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)
- New feature or functionality (change which adds functionality)
- Style (white-space, formatting, etc...)
- Refactor (a code change that neither fixes a bug or adds a new feature)
- Performance (a code change that improves performance)
- Documentation (updates to documentation or READMEs)
- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Relevant documentation has been updated
- Suggested release notes are provided below:

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
