### PR TITLE
Add toolchain param to affected actions 

### DIFF
--- a/docs/copy_directory.md
+++ b/docs/copy_directory.md
@@ -42,7 +42,7 @@ for more context.
 ## copy_directory_bin_action
 
 <pre>
-copy_directory_bin_action(<a href="#copy_directory_bin_action-ctx">ctx</a>, <a href="#copy_directory_bin_action-src">src</a>, <a href="#copy_directory_bin_action-dst">dst</a>, <a href="#copy_directory_bin_action-copy_directory_bin">copy_directory_bin</a>, <a href="#copy_directory_bin_action-hardlink">hardlink</a>, <a href="#copy_directory_bin_action-verbose">verbose</a>)
+copy_directory_bin_action(<a href="#copy_directory_bin_action-ctx">ctx</a>, <a href="#copy_directory_bin_action-src">src</a>, <a href="#copy_directory_bin_action-dst">dst</a>, <a href="#copy_directory_bin_action-copy_directory_bin">copy_directory_bin</a>, <a href="#copy_directory_bin_action-hardlink">hardlink</a>, <a href="#copy_directory_bin_action-verbose">verbose</a>, <a href="#copy_directory_bin_action-toolchain_type">toolchain_type</a>)
 </pre>
 
 Factory function that creates an action to copy a directory from src to dst using a tool binary.
@@ -65,5 +65,6 @@ within other rule implementations.
 | <a id="copy_directory_bin_action-copy_directory_bin"></a>copy_directory_bin |  Copy to directory tool binary.   |  none |
 | <a id="copy_directory_bin_action-hardlink"></a>hardlink |  Controls when to use hardlinks to files instead of making copies.<br><br>See copy_directory rule documentation for more details.   |  <code>"auto"</code> |
 | <a id="copy_directory_bin_action-verbose"></a>verbose |  If true, prints out verbose logs to stdout   |  <code>False</code> |
+| <a id="copy_directory_bin_action-toolchain_type"></a>toolchain_type |  <p align="center"> - </p>   |  <code>"@aspect_bazel_lib//lib:copy_directory_toolchain_type"</code> |
 
 

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -12,7 +12,8 @@ def copy_directory_bin_action(
         dst,
         copy_directory_bin,
         hardlink = "auto",
-        verbose = False):
+        verbose = False,
+        toolchain_type = "@aspect_bazel_lib//lib:copy_directory_toolchain_type"):
     """Factory function that creates an action to copy a directory from src to dst using a tool binary.
 
     The tool binary will typically be the `@aspect_bazel_lib//tools/copy_directory` `go_binary`
@@ -52,6 +53,7 @@ def copy_directory_bin_action(
         inputs = [src],
         outputs = [dst],
         executable = copy_directory_bin,
+        toolchain = toolchain_type,
         arguments = args,
         mnemonic = "CopyDirectory",
         progress_message = "Copying directory %s" % _progress_path(src),

--- a/lib/private/copy_file.bzl
+++ b/lib/private/copy_file.bzl
@@ -85,6 +85,7 @@ def copy_file_action(ctx, src, dst, dir_path = None):
 
     ctx.actions.run(
         executable = coreutils.bin,
+        toolchain = _COREUTILS_TOOLCHAIN,
         arguments = ["cp", src_path, dst.path],
         inputs = [src],
         outputs = [dst],

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -488,6 +488,7 @@ def copy_to_directory_bin_action(
         inputs = file_inputs + [config_file],
         outputs = [dst],
         executable = copy_to_directory_bin,
+        toolchain = "@aspect_bazel_lib//lib:copy_to_directory_toolchain_type",
         arguments = [config_file.path, ctx.label.workspace_name],
         mnemonic = "CopyToDirectory",
         progress_message = "Copying files to directory %s" % _progress_path(dst),

--- a/lib/private/expand_template.bzl
+++ b/lib/private/expand_template.bzl
@@ -52,6 +52,7 @@ def _expand_template_impl(ctx):
             outputs = [output],
             inputs = inputs,
             executable = expand_template_info.bin,
+            toolchain = "@aspect_bazel_lib//lib:expand_template_toolchain_type",
         )
     else:
         ctx.actions.expand_template(

--- a/lib/private/jq.bzl
+++ b/lib/private/jq.bzl
@@ -44,6 +44,7 @@ def _jq_impl(ctx):
         stamp_json = ctx.actions.declare_file("_%s_stamp.json" % ctx.label.name)
         ctx.actions.run_shell(
             tools = [jq_bin],
+            toolchain = "@aspect_bazel_lib//lib:jq_toolchain_type",
             inputs = [stamp.stable_status_file, stamp.volatile_status_file, ctx.file._parse_status_file_filter],
             outputs = [stamp_json],
             command = "{jq} -s -R -f {filter} {stable} {volatile} > {out}".format(
@@ -69,6 +70,7 @@ def _jq_impl(ctx):
 
     ctx.actions.run_shell(
         tools = [jq_bin],
+        toolchain = "@aspect_bazel_lib//lib:jq_toolchain_type",
         inputs = inputs,
         outputs = [out],
         command = cmd,

--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -79,6 +79,7 @@ Possible fixes:
         use_default_shell_env = False,
         env = dicts.add(ctx.configuration.default_shell_env, envs),
         input_manifests = tool_input_mfs,
+        toolchain = None,
     )
     return DefaultInfo(
         files = depset(outputs),

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -108,6 +108,7 @@ def _tar_impl(ctx):
 
     ctx.actions.run(
         executable = bsdtar.tarinfo.binary,
+        toolchain = "@aspect_bazel_lib//lib:tar_toolchain_type",
         inputs = depset(direct = inputs, transitive = [bsdtar.default.files] + [
             src[DefaultInfo].default_runfiles.files
             for src in ctx.attr.srcs

--- a/lib/private/yq.bzl
+++ b/lib/private/yq.bzl
@@ -50,6 +50,7 @@ def _yq_impl(ctx):
         # create an action that gives a YAML representation of the stamp keys
         ctx.actions.run_shell(
             tools = [yq_bin],
+            toolchain = "@aspect_bazel_lib//lib:yq_toolchain_type",
             inputs = [stamp.stable_status_file, stamp.volatile_status_file, ctx.file._parse_status_file_expression],
             outputs = [stamp_yaml],
             command = "{yq} --from-file {expression} {stable} {volatile} > {out}".format(
@@ -86,6 +87,7 @@ def _yq_impl(ctx):
 
     ctx.actions.run_shell(
         tools = [yq_bin],
+        toolchain = "@aspect_bazel_lib//lib:yq_toolchain_type",
         inputs = inputs,
         outputs = outs,
         command = cmd,

--- a/lib/tests/copy_directory_bin_action/pkg.bzl
+++ b/lib/tests/copy_directory_bin_action/pkg.bzl
@@ -27,6 +27,7 @@ def _pkg_impl(ctx):
         copy_directory_bin = ctx.executable._tool,
         hardlink = "auto",
         verbose = True,
+        toolchain_type = None,
     )
 
     return [


### PR DESCRIPTION
This is part of migrations of Automatic Exec Groups (AEGs) where a `toolchain` parameter should be set inside actions which use executable or tools from a toolchain. 

AEGs are under an incompatible flag right now, but will be flipped soon in Bazel 7. I've added this change since I was manually fixing rules_nodejs, which depends on bazel-lib. I can't fully test this change since I need at least Bazel 7, but Bazel@Head raises non related errors to my change. That's why there might be more related updates once bazel-lib supports Bazel 7.

Still, as I already mentioned, adding a toolchain parameter is masked by the incompatible flag, so these changes don't do anything right now. But it can help you with your migration in the near future when AEGs are enabled by default and you are forced to update actions which use toolchains. 

Also note that the `toolchain` parameter is available from Bazel 6, but the full logic (and the incompatible flag) will be available from Bazel 7.

Please check [official documentation for Automatic Exec Groups](https://bazel.build/extending/auto-exec-groups) for additional info.

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- Manual testing; please provide instructions so we can reproduce: 
- Use (at least) Bazel 7 and add `--incompatible_auto_exec_groups` flag.
