### PR TITLE
chore(deps): update coreutils to v0.0.27

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -108,7 +108,7 @@ Registers coreutils toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_coreutils_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  `"coreutils"` |
-| <a id="register_coreutils_toolchains-version"></a>version |  the version of coreutils to execute (see https://github.com/uutils/coreutils/releases)   |  `"0.0.26"` |
+| <a id="register_coreutils_toolchains-version"></a>version |  the version of coreutils to execute (see https://github.com/uutils/coreutils/releases)   |  `"0.0.27"` |
 | <a id="register_coreutils_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  `True` |
 
 

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -34,35 +34,33 @@ COREUTILS_PLATFORMS = {
     ),
 }
 
-DEFAULT_COREUTILS_VERSION = "0.0.26"
+DEFAULT_COREUTILS_VERSION = "0.0.27"
 
 # https://github.com/uutils/coreutils/releases
 #
 # The integrity hashes can be automatically fetched for the coreutils releases by running
 # `tools/coreutils_mirror_release.sh`.
 COREUTILS_VERSIONS = {
-    "0.0.26": {
+    "0.0.27": {
         "darwin_arm64": {
-            "filename": "coreutils-0.0.26-aarch64-apple-darwin.tar.gz",
-            "sha256": "sha256-/A6CNYWmvOwPW443pH+wO+VtzDFgussN1hRGuANnFOU=",
+            "filename": "coreutils-0.0.27-aarch64-apple-darwin.tar.gz",
+            "sha256": "sha256-BjAeGgJ8+sLCIwmokCOkfelCCLtnNRH49QcFnrDq8a4=",
         },
         "linux_arm64": {
-            "filename": "coreutils-0.0.26-aarch64-unknown-linux-musl.tar.gz",
-            "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A=",
+            "filename": "coreutils-0.0.27-aarch64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-doU+ZfTyA5I8RSwDAcsOkEI3BZXFuFwBfEbg+diS06g=",
         },
         "darwin_amd64": {
-            # TODO: remove this version_override hack once 0.0.27 is releases and contains a darwin arm binary
-            "version_override": "0.0.23",
-            "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
-            "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
+            "filename": "coreutils-0.0.27-x86_64-apple-darwin.tar.gz",
+            "sha256": "sha256-1ivz4ue8/ROUYhPh22Bg2ASPgC6MKMulR52nLgZvTBo=",
         },
         "windows_amd64": {
-            "filename": "coreutils-0.0.26-x86_64-pc-windows-msvc.zip",
-            "sha256": "sha256-6qPkqxQZM4XBBBJ80t1uvzfZiz0gBeT/zoCdfqOO3uk=",
+            "filename": "coreutils-0.0.27-x86_64-pc-windows-msvc.zip",
+            "sha256": "sha256-DC4H+hQX51aHoFudV39n7u217NDcNL9AiG4o4edboV0=",
         },
         "linux_amd64": {
-            "filename": "coreutils-0.0.26-x86_64-unknown-linux-musl.tar.gz",
-            "sha256": "sha256-QpGVp3wmHqpt5Brd/bdj7pyMQNftcihOtaRI8z2uhp0=",
+            "filename": "coreutils-0.0.27-x86_64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-tM+hJd16cCjflJyMwsCaevPYZMiBkIKZJm7/XC+760w=",
         },
     },
 }

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -34,8 +34,6 @@ COREUTILS_PLATFORMS = {
     ),
 }
 
-DEFAULT_COREUTILS_VERSION = "0.0.27"
-
 # https://github.com/uutils/coreutils/releases
 #
 # The integrity hashes can be automatically fetched for the coreutils releases by running
@@ -63,7 +61,33 @@ COREUTILS_VERSIONS = {
             "sha256": "sha256-tM+hJd16cCjflJyMwsCaevPYZMiBkIKZJm7/XC+760w=",
         },
     },
+    "0.0.26": {
+        "darwin_arm64": {
+            "filename": "coreutils-0.0.26-aarch64-apple-darwin.tar.gz",
+            "sha256": "sha256-/A6CNYWmvOwPW443pH+wO+VtzDFgussN1hRGuANnFOU=",
+        },
+        "linux_arm64": {
+            "filename": "coreutils-0.0.26-aarch64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-9zGLFOMDjUDbraDY/hrE5zFJ0O+QYrvx2wHk3Gw3q/A=",
+        },
+        "darwin_amd64": {
+            # TODO: remove this version_override hack once 0.0.27 is releases and contains a darwin arm binary
+            "version_override": "0.0.23",
+            "filename": "coreutils-0.0.23-x86_64-apple-darwin.tar.gz",
+            "sha256": "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
+        },
+        "windows_amd64": {
+            "filename": "coreutils-0.0.26-x86_64-pc-windows-msvc.zip",
+            "sha256": "sha256-6qPkqxQZM4XBBBJ80t1uvzfZiz0gBeT/zoCdfqOO3uk=",
+        },
+        "linux_amd64": {
+            "filename": "coreutils-0.0.26-x86_64-unknown-linux-musl.tar.gz",
+            "sha256": "sha256-QpGVp3wmHqpt5Brd/bdj7pyMQNftcihOtaRI8z2uhp0=",
+        },
+    },
 }
+
+DEFAULT_COREUTILS_VERSION = COREUTILS_VERSIONS.keys()[0]
 
 CoreUtilsInfo = provider(
     doc = "Provide info for executing coreutils",


### PR DESCRIPTION
This release has an `aarch64-apple-darwin` binary, eliminating the need for a `version_override` hack to support that platform.

---

### Changes are visible to end-users: no

### Test plan

```
bazel test ...
cd e2e/smoke
bazel test ...
```

All previously passing tests still pass; `//lib/tests/transitions:transitioned_go_test_arm64` fails in the same way it had before (on a Darwin / ARM machine).