### PR TITLE
feat: performance preset: nobuild_runfiles_links

### DIFF
--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -21,4 +21,4 @@ build --nolegacy_external_runfiles
 
 # Avoid creating the runfiles tree for binaries until it is needed.
 # See https://github.com/bazelbuild/bazel/issues/6627
-build --nobuild_runfiles_links
+build --nobuild_runfile_links

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -19,6 +19,11 @@ build --experimental_reuse_sandbox_directories
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
 
-# Avoid creating the runfiles tree for binaries until it is needed.
+# Avoid creating a runfiles tree for binaries or tests until it is needed.
+# Docs: https://bazel.build/reference/command-line-reference#flag--build_runfile_links
 # See https://github.com/bazelbuild/bazel/issues/6627
+#
+# This may break local workflows that `build` a binary target, then run the resulting program
+# outside of `bazel run`. In those cases, the script will need to call
+# `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
 build --nobuild_runfile_links

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -18,3 +18,7 @@ build --experimental_reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
+
+# Avoid creating the runfiles tree for binaries until it is needed.
+# See https://github.com/bazelbuild/bazel/issues/6627
+build --nobuild_runfiles_links


### PR DESCRIPTION
Noticed this in https://github.com/EngFlow/bazel_invocation_analyzer/issues/107

---

### Changes are visible to end-users: yes

### Test plan
Not sure. Maybe we should try enabling this flag at several client sites and see if it sticks.