### PR TITLE
chore: update git urls

### DIFF
--- a/.aspect/bazelrc/README.md
+++ b/.aspect/bazelrc/README.md
@@ -13,7 +13,7 @@ and some vary depending on the version of Bazel you use or languages used.
 Bazel rc files can contain `import` statements, which allow you to organize the content better.
 
 To use these presets in your project, simply vendor the `*.bazelrc` files from
-https://github.com/aspect-build/bazel-lib/tree/main/.aspect/bazelrc into the
+https://github.com/bazel-contrib/bazel-lib/tree/main/.aspect/bazelrc into the
 `.aspect/bazelrc` folder in your repository and `import` them in your `.bazelrc` file.
 
 For example,

--- a/.aspect/bazelrc/bazel6.bazelrc
+++ b/.aspect/bazelrc/bazel6.bazelrc
@@ -20,7 +20,7 @@ build --noexperimental_action_cache_store_output_metadata
 # when local debugging.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
 # NB: This flag is in bazel6.bazelrc as when used in Bazel 7 is has been observed to break
-# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/aspect-build/bazel-lib/pull/711
+# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/bazel-contrib/bazel-lib/pull/711
 # for more info.
 build --noexperimental_check_output_files
 fetch --noexperimental_check_output_files

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -24,7 +24,7 @@ test --test_verbose_timeout_warnings
 # Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
 # notices when a directory changes, if you have a directory listed in the srcs of some target.
 # Recommended when using
-# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md) and
 # [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
 # inputs to copy_directory actions.
 # Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args

--- a/.aspect/bazelrc/usage.md
+++ b/.aspect/bazelrc/usage.md
@@ -7,7 +7,7 @@ and some vary depending on the version of Bazel you use or languages used.
 Bazel rc files can contain `import` statements, which allow you to organize the content better.
 
 To use these presets in your project, simply vendor the `*.bazelrc` files from
-https://github.com/aspect-build/bazel-lib/tree/main/.aspect/bazelrc into the
+https://github.com/bazel-contrib/bazel-lib/tree/main/.aspect/bazelrc into the
 `.aspect/bazelrc` folder in your repository and `import` them in your `.bazelrc` file.
 
 For example,

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -67,7 +67,7 @@ http_archive(
     name = "aspect_bazel_lib",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/${TAG}/${ARCHIVE}",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/${TAG}/${ARCHIVE}",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,7 +13,7 @@ load("//lib:yq.bzl", "yq")
 
 exports_files([".shellcheckrc"])
 
-# gazelle:prefix github.com/aspect-build/bazel-lib
+# gazelle:prefix github.com/bazel-contrib/bazel-lib
 
 gazelle_binary(
     name = "gazelle_bin",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aspect's Bazel helpers library
+# Bazel helpers library
 
 Base Starlark libraries and basic Bazel rules which are useful for constructing rulesets and BUILD files.
 
@@ -6,23 +6,18 @@ This module depends on [bazel-skylib](https://github.com/bazelbuild/bazel-skylib
 In theory all these utilities could be upstreamed to bazel-skylib, but the declared scope of that project
 is narrow and it's very difficult to get anyone's attention to review PRs there.
 
-bazel-lib is just a part of what Aspect provides:
-
-- _Need help?_ This ruleset has support provided by https://aspect.dev.
-- See our other Bazel rules: https://github.com/aspect-build
-
 ## Installation
 
 Installation instructions are included on each release:
-<https://github.com/aspect-build/bazel-lib/releases>
+<https://github.com/bazel-contrib/bazel-lib/releases>
 
 To use a commit rather than a release, you can point at any SHA of the repo.
 
 For example to use commit `abc123`:
 
-1. Replace `url = "https://github.com/aspect-build/bazel-lib/releases/download/v0.1.0/bazel-lib-v0.1.0.tar.gz"`
+1. Replace `url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v0.1.0/bazel-lib-v0.1.0.tar.gz"`
    with a GitHub-provided source archive like
-   `url = "https://github.com/aspect-build/bazel-lib/archive/abc123.tar.gz"`
+   `url = "https://github.com/bazel-contrib/bazel-lib/archive/abc123.tar.gz"`
 1. Replace `strip_prefix = "bazel-lib-0.1.0"` with `strip_prefix = "bazel-lib-abc123"`
 1. Update the `sha256`. The easiest way to do this is to comment out the line, then Bazel will
    print a message with the correct value.

--- a/docs/expand_template.md
+++ b/docs/expand_template.md
@@ -17,10 +17,10 @@ This performs a simple search over the template file for the keys in substitutio
 and replaces them with the corresponding values.
 
 Values may also use location templates as documented in
-[expand_locations](https://github.com/aspect-build/bazel-lib/blob/main/docs/expand_make_vars.md#expand_locations)
+[expand_locations](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/expand_make_vars.md#expand_locations)
 as well as [configuration variables](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#var)
 such as `$(BINDIR)`, `$(TARGET_CPU)`, and `$(COMPILATION_MODE)` as documented in
-[expand_variables](https://github.com/aspect-build/bazel-lib/blob/main/docs/expand_make_vars.md#expand_variables).
+[expand_variables](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/expand_make_vars.md#expand_variables).
 
 **ATTRIBUTES**
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -142,7 +142,7 @@ Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE an
 be used in rules and BUILD files.
 
 An alternate approach to make the Bazel version available in BUILD files and rules would be to
-use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
 which contains the bazel_version in the exported `host` struct:
 
 WORKSPACE:
@@ -180,7 +180,7 @@ Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE an
 be used in rules and BUILD files.
 
 An alternate approach to make the Bazel version available in BUILD files and rules would be to
-use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
 which contains the bazel_version in the exported `host` struct:
 
 WORKSPACE:
@@ -564,7 +564,7 @@ Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE an
 be used in rules and BUILD files.
 
 An alternate approach to make the Bazel version available in BUILD files and rules would be to
-use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
 which contains the bazel_version in the exported `host` struct:
 
 WORKSPACE:
@@ -602,7 +602,7 @@ Unlike the undocumented `native.bazel_version`, which only works in WORKSPACE an
 be used in rules and BUILD files.
 
 An alternate approach to make the Bazel version available in BUILD files and rules would be to
-use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
 which contains the bazel_version in the exported `host` struct:
 
 WORKSPACE:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aspect-build/bazel-lib
+module github.com/bazel-contrib/bazel-lib
 
 go 1.19
 

--- a/lib/private/copy_directory_toolchain.bzl
+++ b/lib/private/copy_directory_toolchain.bzl
@@ -1,6 +1,6 @@
 "Setup copy_directory toolchain repositories and rules"
 
-# https://github.com/aspect-build/bazel-lib/releases
+# https://github.com/bazel-contrib/bazel-lib/releases
 load("//tools:integrity.bzl", "RELEASED_BINARY_INTEGRITY")
 load("//tools:version.bzl", "VERSION")
 
@@ -153,8 +153,8 @@ def _copy_directory_platform_repo_impl(rctx):
     release_platform = meta.release_platform if hasattr(meta, "release_platform") else rctx.attr.platform
     release_file = "copy_directory-{}{}".format(release_platform, ".exe" if is_windows else "")
 
-    # https://github.com/aspect-build/bazel-lib/releases/download/v1.19.0/copy_directory-linux_amd64
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v{}/{}".format(
+    # https://github.com/bazel-contrib/bazel-lib/releases/download/v1.19.0/copy_directory-linux_amd64
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v{}/{}".format(
         VERSION,
         release_file,
     )

--- a/lib/private/copy_to_directory_toolchain.bzl
+++ b/lib/private/copy_to_directory_toolchain.bzl
@@ -1,6 +1,6 @@
 "Setup copy_to_directory toolchain repositories and rules"
 
-# https://github.com/aspect-build/bazel-lib/releases
+# https://github.com/bazel-contrib/bazel-lib/releases
 load("//tools:integrity.bzl", "RELEASED_BINARY_INTEGRITY")
 load("//tools:version.bzl", "VERSION")
 
@@ -153,8 +153,8 @@ def _copy_to_directory_platform_repo_impl(rctx):
     release_platform = meta.release_platform if hasattr(meta, "release_platform") else rctx.attr.platform
     release_file = "copy_to_directory-{}{}".format(release_platform, ".exe" if is_windows else "")
 
-    # https://github.com/aspect-build/bazel-lib/releases/download/v1.19.0/copy_to_directory-linux_amd64
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v{}/{}".format(
+    # https://github.com/bazel-contrib/bazel-lib/releases/download/v1.19.0/copy_to_directory-linux_amd64
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v{}/{}".format(
         VERSION,
         release_file,
     )

--- a/lib/private/expand_template.bzl
+++ b/lib/private/expand_template.bzl
@@ -69,10 +69,10 @@ This performs a simple search over the template file for the keys in substitutio
 and replaces them with the corresponding values.
 
 Values may also use location templates as documented in
-[expand_locations](https://github.com/aspect-build/bazel-lib/blob/main/docs/expand_make_vars.md#expand_locations)
+[expand_locations](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/expand_make_vars.md#expand_locations)
 as well as [configuration variables](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#var)
 such as `$(BINDIR)`, `$(TARGET_CPU)`, and `$(COMPILATION_MODE)` as documented in
-[expand_variables](https://github.com/aspect-build/bazel-lib/blob/main/docs/expand_make_vars.md#expand_variables).
+[expand_variables](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/expand_make_vars.md#expand_variables).
 """,
     implementation = _expand_template_impl,
     toolchains = ["@aspect_bazel_lib//lib:expand_template_toolchain_type"],

--- a/lib/private/expand_template_toolchain.bzl
+++ b/lib/private/expand_template_toolchain.bzl
@@ -1,6 +1,6 @@
 "Setup expand_template toolchain repositories and rules"
 
-# https://github.com/aspect-build/bazel-lib/releases
+# https://github.com/bazel-contrib/bazel-lib/releases
 load("//tools:integrity.bzl", "RELEASED_BINARY_INTEGRITY")
 load("//tools:version.bzl", "VERSION")
 
@@ -153,8 +153,8 @@ def _expand_template_platform_repo_impl(rctx):
     release_platform = meta.release_platform if hasattr(meta, "release_platform") else rctx.attr.platform
     release_file = "expand_template-{}{}".format(release_platform, ".exe" if is_windows else "")
 
-    # https://github.com/aspect-build/bazel-lib/releases/download/v1.19.0/expand_template-linux_amd64
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v{}/{}".format(
+    # https://github.com/bazel-contrib/bazel-lib/releases/download/v1.19.0/expand_template-linux_amd64
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v{}/{}".format(
         VERSION,
         release_file,
     )

--- a/lib/private/utils.bzl
+++ b/lib/private/utils.bzl
@@ -180,7 +180,7 @@ def _is_bazel_6_or_greater():
     be used in rules and BUILD files.
 
     An alternate approach to make the Bazel version available in BUILD files and rules would be to
-    use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+    use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
     which contains the bazel_version in the exported `host` struct:
 
     WORKSPACE:
@@ -212,7 +212,7 @@ def _is_bazel_7_or_greater():
     be used in rules and BUILD files.
 
     An alternate approach to make the Bazel version available in BUILD files and rules would be to
-    use the [host_repo](https://github.com/aspect-build/bazel-lib/blob/main/docs/host_repo.md) repository rule
+    use the [host_repo](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/host_repo.md) repository rule
     which contains the bazel_version in the exported `host` struct:
 
     WORKSPACE:

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -164,7 +164,7 @@ _write_source_file_attrs = {
     # out_file in the list of source file deps. ibazel uses this query to determine
     # which source files to watch so if the out_file is returned then ibazel watches
     # and it goes into an infinite update, notify loop when running this target.
-    # See https://github.com/aspect-build/bazel-lib/pull/52 for more context.
+    # See https://github.com/bazel-contrib/bazel-lib/pull/52 for more context.
     "out_file": attr.string(mandatory = False),
     "executable": attr.bool(),
     # buildifier: disable=attr-cfg

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -49,7 +49,7 @@ YQ_PLATFORMS = {
 }
 
 # Note: this is not the latest release, because it has significant breaking changes.
-# See https://github.com/aspect-build/bazel-lib/pull/421
+# See https://github.com/bazel-contrib/bazel-lib/pull/421
 DEFAULT_YQ_VERSION = "4.25.2"
 
 # https://github.com/mikefarah/yq/releases

--- a/lib/tests/bazelrc_presets/all/bazel6.bazelrc
+++ b/lib/tests/bazelrc_presets/all/bazel6.bazelrc
@@ -20,7 +20,7 @@ build --noexperimental_action_cache_store_output_metadata
 # when local debugging.
 # Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
 # NB: This flag is in bazel6.bazelrc as when used in Bazel 7 is has been observed to break
-# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/aspect-build/bazel-lib/pull/711
+# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/bazel-contrib/bazel-lib/pull/711
 # for more info.
 build --noexperimental_check_output_files
 fetch --noexperimental_check_output_files

--- a/lib/tests/bazelrc_presets/all/correctness.bazelrc
+++ b/lib/tests/bazelrc_presets/all/correctness.bazelrc
@@ -24,7 +24,7 @@ test --test_verbose_timeout_warnings
 # Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
 # notices when a directory changes, if you have a directory listed in the srcs of some target.
 # Recommended when using
-# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md) and
 # [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
 # inputs to copy_directory actions.
 # Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args

--- a/lib/tests/bazelrc_presets/all/write_aspect_bazelrc_presets.bzl
+++ b/lib/tests/bazelrc_presets/all/write_aspect_bazelrc_presets.bzl
@@ -7,5 +7,5 @@ def write_aspect_bazelrc_presets(**kwargs):
     if host.bazel_version[0] == "6":
         # Don't stamp this target out if we're testing against Bazel 5 or 7. The bazel6.bazelrc file is
         # deleted on CI when testing Bazel 5 which breaks analysis for this target. See
-        # https://github.com/aspect-build/bazel-lib/blob/fff5f10ad8e6921a45816e256f588d8020b3f2ee/.github/workflows/ci.yaml#L145.
+        # https://github.com/bazel-contrib/bazel-lib/blob/fff5f10ad8e6921a45816e256f588d8020b3f2ee/.github/workflows/ci.yaml#L145.
         _write_aspect_bazelrc_presets(**kwargs)

--- a/lib/tests/copy_to_directory/BUILD.bazel
+++ b/lib/tests/copy_to_directory/BUILD.bazel
@@ -273,7 +273,7 @@ copy_directory(
 )
 
 # Case 11: two inputs with same subfolders
-# regression test for https://github.com/aspect-build/bazel-lib/issues/133
+# regression test for https://github.com/bazel-contrib/bazel-lib/issues/133
 copy_to_directory(
     name = "case_11",
     srcs = [

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -27,7 +27,7 @@ lib(
     others = [
         "1",
         # also pass in a copy_to_bin copy of "1" to spice things up;
-        # this case is handled in the fix in https://github.com/aspect-build/bazel-lib/pull/205
+        # this case is handled in the fix in https://github.com/bazel-contrib/bazel-lib/pull/205
         "copy_1",
         "2",
         "d",

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -201,6 +201,6 @@ sh_test(
 go_library(
     name = "transitions_lib",
     srcs = ["main.go"],
-    importpath = "github.com/aspect-build/bazel-lib/lib/tests/transitions",
+    importpath = "github.com/bazel-contrib/bazel-lib/lib/tests/transitions",
     visibility = ["//visibility:private"],
 )

--- a/tools/common/BUILD.bazel
+++ b/tools/common/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "copy.go",
         "file.go",
     ],
-    importpath = "github.com/aspect-build/bazel-lib/tools/common",
+    importpath = "github.com/bazel-contrib/bazel-lib/tools/common",
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:darwin": [

--- a/tools/copy_directory/BUILD.bazel
+++ b/tools/copy_directory/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "copy_directory_lib",
     srcs = ["main.go"],
-    importpath = "github.com/aspect-build/bazel-lib/tools/copy_directory",
+    importpath = "github.com/bazel-contrib/bazel-lib/tools/copy_directory",
     visibility = ["//visibility:public"],
     deps = ["//tools/common"],
 )

--- a/tools/copy_directory/main.go
+++ b/tools/copy_directory/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/aspect-build/bazel-lib/tools/common"
+	"github.com/bazel-contrib/bazel-lib/tools/common"
 )
 
 type pathSet map[string]bool

--- a/tools/copy_to_directory/BUILD.bazel
+++ b/tools/copy_to_directory/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "copy_to_directory_lib",
     srcs = ["main.go"],
-    importpath = "github.com/aspect-build/bazel-lib/tools/copy_to_directory",
+    importpath = "github.com/bazel-contrib/bazel-lib/tools/copy_to_directory",
     visibility = ["//visibility:public"],
     deps = [
         "//tools/common",

--- a/tools/copy_to_directory/main.go
+++ b/tools/copy_to_directory/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aspect-build/bazel-lib/tools/common"
+	"github.com/bazel-contrib/bazel-lib/tools/common"
 	"github.com/bmatcuk/doublestar/v4"
 	"golang.org/x/exp/maps"
 )

--- a/tools/expand_template/BUILD.bazel
+++ b/tools/expand_template/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "expand_template_lib",
     srcs = ["main.go"],
-    importpath = "github.com/aspect-build/bazel-lib/tools/expand_template",
+    importpath = "github.com/bazel-contrib/bazel-lib/tools/expand_template",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_exp//maps"],
 )


### PR DESCRIPTION
This repository was donated to the Linux Foundation and is now in the bazel-contrib GH org.

Also remove mentions of Aspect from the README.