### PR TITLE
perf: Improve copy_file.bzl's progress_message and do some cleanup

### DIFF
--- a/docs/copy_directory.md
+++ b/docs/copy_directory.md
@@ -2,8 +2,7 @@
 
 A rule that copies a directory to another place.
 
-The rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command
-on Windows (no Bash is required).
+The rule uses a precompiled binary to perform the copy, so no shell is required.
 
 <a id="copy_directory"></a>
 
@@ -15,7 +14,7 @@ copy_directory(<a href="#copy_directory-name">name</a>, <a href="#copy_directory
 
 Copies a directory to another location.
 
-This rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command on Windows (no Bash is required).
+This rule uses a precompiled binary to perform the copy, so no shell is required.
 
 If using this rule with source directories, it is recommended that you use the
 `--host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1` startup option so that changes

--- a/docs/copy_file.md
+++ b/docs/copy_file.md
@@ -5,8 +5,7 @@ A rule that copies a file to another place.
 `native.genrule()` is sometimes used to copy files (often wishing to rename them).
 The `copy_file` rule does this with a simpler interface than genrule.
 
-The rule uses a Bash command on Linux/macOS/non-Windows, and a `cmd.exe` command
-on Windows (no Bash is required).
+This rule uses a hermetic uutils/coreutils `cp` binary, no shell is required.
 
 This fork of bazel-skylib's copy_file adds `DirectoryPathInfo` support and allows multiple
 `copy_file` rules in the same package.
@@ -23,7 +22,7 @@ Copies a file or directory to another location.
 
 `native.genrule()` is sometimes used to copy files (often wishing to rename them). The 'copy_file' rule does this with a simpler interface than genrule.
 
-This rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command on Windows (no Bash is required).
+This rule uses a hermetic uutils/coreutils `cp` binary, no shell is required.
 
 If using this rule with source directories, it is recommended that you use the
 `--host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1` startup option so that changes

--- a/lib/copy_directory.bzl
+++ b/lib/copy_directory.bzl
@@ -1,7 +1,6 @@
 """A rule that copies a directory to another place.
 
-The rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command
-on Windows (no Bash is required).
+The rule uses a precompiled binary to perform the copy, so no shell is required.
 """
 
 load(

--- a/lib/copy_file.bzl
+++ b/lib/copy_file.bzl
@@ -22,8 +22,7 @@
 `native.genrule()` is sometimes used to copy files (often wishing to rename them).
 The `copy_file` rule does this with a simpler interface than genrule.
 
-The rule uses a Bash command on Linux/macOS/non-Windows, and a `cmd.exe` command
-on Windows (no Bash is required).
+This rule uses a hermetic uutils/coreutils `cp` binary, no shell is required.
 
 This fork of bazel-skylib's copy_file adds `DirectoryPathInfo` support and allows multiple
 `copy_file` rules in the same package.

--- a/lib/private/copy_common.bzl
+++ b/lib/private/copy_common.bzl
@@ -12,15 +12,3 @@ COPY_EXECUTION_REQUIREMENTS = {
     # output file/directory so little room for non-hermetic inputs to sneak in to the execution.
     "no-sandbox": "1",
 }
-
-def progress_path(f):
-    """
-    Convert a file to an appropriate string to display in an action progress message.
-
-    Args:
-        f: a file to show as a path in a progress message
-
-    Returns:
-        The path formatted for use in a progress message
-    """
-    return f.short_path.removeprefix("../")

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -1,7 +1,6 @@
 """Implementation of copy_directory macro and underlying rules.
 
-This rule copies a directory to another location using Bash (on Linux/macOS) or
-cmd.exe (on Windows).
+This rule copies a directory to another location using a precompiled binary.
 """
 
 load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
@@ -123,7 +122,7 @@ def copy_directory(
         **kwargs):
     """Copies a directory to another location.
 
-    This rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command on Windows (no Bash is required).
+    This rule uses a precompiled binary to perform the copy, so no shell is required.
 
     If using this rule with source directories, it is recommended that you use the
     `--host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1` startup option so that changes

--- a/lib/private/copy_directory.bzl
+++ b/lib/private/copy_directory.bzl
@@ -4,7 +4,7 @@ This rule copies a directory to another location using Bash (on Linux/macOS) or
 cmd.exe (on Windows).
 """
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
+load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
 
 def copy_directory_bin_action(
         ctx,
@@ -60,7 +60,7 @@ def copy_directory_bin_action(
         executable = copy_directory_bin,
         arguments = args,
         mnemonic = "CopyDirectory",
-        progress_message = "Copying directory %s" % _progress_path(src),
+        progress_message = "Copying directory %{input}",
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
 

--- a/lib/private/copy_to_directory.bzl
+++ b/lib/private/copy_to_directory.bzl
@@ -1,6 +1,6 @@
 "copy_to_directory implementation"
 
-load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS", _progress_path = "progress_path")
+load(":copy_common.bzl", _COPY_EXECUTION_REQUIREMENTS = "COPY_EXECUTION_REQUIREMENTS")
 load(":directory_path.bzl", "DirectoryPathInfo")
 load(":paths.bzl", "paths")
 
@@ -497,7 +497,7 @@ def copy_to_directory_bin_action(
         executable = copy_to_directory_bin,
         arguments = [config_file.path, ctx.label.workspace_name],
         mnemonic = "CopyToDirectory",
-        progress_message = "Copying files to directory %s" % _progress_path(dst),
+        progress_message = "Copying files to directory %{output}",
         execution_requirements = _COPY_EXECUTION_REQUIREMENTS,
     )
 


### PR DESCRIPTION
The change to `progress_message` saves around 100ms of analysis time for my big repo. The rest of the changes are cleanups to reflect that we have long since diverged from skylib's implementation.