### PR TITLE
fix(presets): restore build runfile links for the 'coverage' command

### DIFF
--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -27,3 +27,4 @@ build --nolegacy_external_runfiles
 # outside of `bazel run`. In those cases, the script will need to call
 # `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
 build --nobuild_runfile_links
+coverage --build_runfile_links # However, the above breaks a fetch of the gcov tool, see #922

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -28,6 +28,6 @@ build --nolegacy_external_runfiles
 # `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
 build --nobuild_runfile_links
 
-# Needed prior to Bazel 7.4, see
+# Needed prior to Bazel 8; see
 # https://github.com/bazelbuild/bazel/issues/20577
 coverage --build_runfile_links

--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -27,4 +27,7 @@ build --nolegacy_external_runfiles
 # outside of `bazel run`. In those cases, the script will need to call
 # `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
 build --nobuild_runfile_links
-coverage --build_runfile_links # However, the above breaks a fetch of the gcov tool, see #922
+
+# Needed prior to Bazel 7.4, see
+# https://github.com/bazelbuild/bazel/issues/20577
+coverage --build_runfile_links


### PR DESCRIPTION
A user reported that this flag broke `coverage` because it makes assumptions about locating tools: https://github.com/bazelbuild/bazel/issues/20577