### PR TITLE
fix: unknown repo error with mtree_mutate and Bzlmod

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -119,7 +119,7 @@ Modify metadata in an mtree file.
 | <a id="mtree_mutate-mtime"></a>mtime |  new modification time for all entries.   |  `None` |
 | <a id="mtree_mutate-owner"></a>owner |  new uid for all entries.   |  `None` |
 | <a id="mtree_mutate-ownername"></a>ownername |  new uname for all entries.   |  `None` |
-| <a id="mtree_mutate-awk_script"></a>awk_script |  may be overridden to change the script containing the modification logic.   |  `"@aspect_bazel_lib//lib/private:modify_mtree.awk"` |
+| <a id="mtree_mutate-awk_script"></a>awk_script |  may be overridden to change the script containing the modification logic.   |  `Label("@aspect_bazel_lib//lib/private:modify_mtree.awk")` |
 | <a id="mtree_mutate-kwargs"></a>kwargs |  additional named parameters to genrule   |  none |
 
 

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -142,7 +142,7 @@ def mtree_mutate(
         mtime = None,
         owner = None,
         ownername = None,
-        awk_script = "@aspect_bazel_lib//lib/private:modify_mtree.awk",
+        awk_script = Label("@aspect_bazel_lib//lib/private:modify_mtree.awk"),
         **kwargs):
     """Modify metadata in an mtree file.
 


### PR DESCRIPTION
With Bzlmod, every repo has its own namespace. Using Label() should make sure it uses the namespace of the .bzl file instead of the caller's one.