### PR TITLE
fix: update metadata.template.json for LF donation

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -12,7 +12,7 @@
       "github": "kormide"
     }
   ],
-  "repository": ["github:aspect-build/bazel-lib"],
+  "repository": ["github:bazel-contrib/bazel-lib"],
   "versions": [],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Required by a BCR presubmit check, which blocked the last two releases.