### PR TITLE
feat: support bzlmod runfiles lookups

### DIFF
--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -259,7 +259,7 @@ def _mtree_impl(ctx):
         )
         if repo_mapping != None:
             content.add(
-                _mtree_line(_vis_encode(runfiles_dir + "/_repo_mapping"), "file", content = _vis_encode(repo_mapping.path))
+                _mtree_line(_vis_encode(runfiles_dir + "/_repo_mapping"), "file", content = _vis_encode(repo_mapping.path)),
             )
 
     ctx.actions.write(out, content = content)

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -185,8 +185,6 @@ genrule(
         # requires runfiles tree, otherwise get
         # ERROR: cannot find bazel_tools/tools/bash/runfiles/runfiles.bash
         "@platforms//os:windows": ["@platforms//:incompatible"],
-        # TODO(sahin): incompatible with bzlmod
-        "@aspect_bazel_lib//lib:bzlmod": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],


### PR DESCRIPTION
Under bzlmod, repos have aliases in addition to their canonical names;
in order for lookups using these alias names to function properly,
a file name `_repo_mapping` is located in the root of the runfiles tree
and consulted to perform repo-name translation.

See: https://github.com/bazelbuild/proposals/blob/main/designs/2022-07-21-locating-runfiles-with-bzlmod.md