### PR TITLE
fix: Use transitioned target platform for `platform_transition_test`

### DIFF
--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("//lib:diff_test.bzl", "diff_test")
 load(
     "//lib:transitions.bzl",
@@ -135,22 +136,16 @@ platform_transition_binary(
 platform_transition_test(
     name = "transitioned_go_test_x86_64",
     binary = ":test_transition_test",
-    # only run this test on x86_64 platforms
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
+    # only run this test on an x86_64 host
+    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == ["@platforms//cpu:x86_64", "@platforms//os:linux"] else ["@platforms//:incompatible"],
     target_platform = "x86_64_linux",
 )
 
 platform_transition_test(
     name = "transitioned_go_test_arm64",
     binary = ":test_transition_test",
-    # only run this test on arm64 platforms
-    target_compatible_with = [
-        "@platforms//cpu:arm64",
-        "@platforms//os:linux",
-    ],
+    # only run this test on an x86_64 host
+    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == ["@platforms//cpu:aarch64", "@platforms//os:linux"] else ["@platforms//:incompatible"],
     target_platform = "arm64_linux",
 )
 


### PR DESCRIPTION
The target platform of a test rule matters for the resolution of the execution platform of the test action, either via test toolchains or `--use_target_platform_for_tests`. With an outgoing transition, tests would run on the wrong platform in these cases, so use an incoming transition for the test rule.