### PR TITLE
feat(bzlmod): mark toolchains extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
+bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 
@@ -79,4 +80,3 @@ use_repo(host_platform, "host_platform")
 bazel_dep(name = "aspect_rules_lint", version = "1.0.0-rc10", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
-bazel_dep(name = "bazel_features", version = "0.2.0", dev_dependency = True)

--- a/lib/extensions.bzl
+++ b/lib/extensions.bzl
@@ -25,6 +25,7 @@ load(
     "register_yq_toolchains",
     "register_zstd_toolchains",
 )
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//lib/private:extension_utils.bzl", "extension_utils")
 load("//lib/private:host_repo.bzl", "host_repo")
 
@@ -116,6 +117,11 @@ def _toolchains_extension_impl(mctx):
         toolchain_repos_fn = lambda name, version: register_bats_toolchains(name = name, core_version = version, register = False),
         get_version_fn = lambda attr: attr.core_version,
     )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return mctx.extension_metadata(reproducible = True)
+
+    return mctx.extension_metadata()
 
 toolchains = module_extension(
     implementation = _toolchains_extension_impl,


### PR DESCRIPTION
Marking the toolchains extension as reproducible since all underlying tools are already checked for integrity. Saving an entry in the lockfile for that extension.

Marking this has to be conditional to `bazel_features.external_deps.extension_metadata_has_reproducible`, hence bumping `bazel_features` to 1.9.0 which is the version introducing the check (https://github.com/bazel-contrib/bazel_features/releases/tag/v1.9.0)
