### PR TITLE
fix: allow_tags_propagation defaults true in 7

### DIFF
--- a/.aspect/bazelrc/bazel6.bazelrc
+++ b/.aspect/bazelrc/bazel6.bazelrc
@@ -33,3 +33,14 @@ query --noexperimental_check_output_files
 # NB: This flag is in bazel6.bazelrc because it became a no-op in Bazel 7 and has been removed
 # in Bazel 8.
 build --incompatible_remote_results_ignore_disk
+
+# Propagate tags from a target declaration to the actions' execution requirements.
+# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
+# get propagated to actions created by the rule.
+# Without this option, you rely on rules authors to manually check the tags you passed
+# and apply relevant ones to the actions they create.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
+fetch --experimental_allow_tags_propagation
+query --experimental_allow_tags_propagation

--- a/.aspect/bazelrc/correctness.bazelrc
+++ b/.aspect/bazelrc/correctness.bazelrc
@@ -42,17 +42,6 @@ test --incompatible_exclusive_test_sandboxed
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
 build --incompatible_strict_action_env
 
-# Propagate tags from a target declaration to the actions' execution requirements.
-# Ensures that tags applied in your BUILD file, like `tags=["no-remote"]`
-# get propagated to actions created by the rule.
-# Without this option, you rely on rules authors to manually check the tags you passed
-# and apply relevant ones to the actions they create.
-# See https://github.com/bazelbuild/bazel/issues/8830 for details.
-# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
-build --experimental_allow_tags_propagation
-fetch --experimental_allow_tags_propagation
-query --experimental_allow_tags_propagation
-
 # Do not automatically create `__init__.py` files in the runfiles of Python targets. Fixes the wrong
 # default that comes from Google's internal monorepo by using `__init__.py` to delimit a Python
 # package. Precisely, when a `py_binary` or `py_test` target has `legacy_create_init` set to `auto (the


### PR DESCRIPTION
It was also renamed from experimental_ to incompatible_, though surprisingly the original flag name is still permitted in Bazel 7 without errors.

Rename and default flip was in https://github.com/bazelbuild/bazel/commit/d0625f5b37e7cfe4ecfcff02b15f634c53d7440c