### PR TITLE
fix: update stardoc module to `0.7.1`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 
 # 0.5.4 is the first version with bzlmod support
-bazel_dep(name = "stardoc", version = "0.6.2", repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_stardoc")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib_toolchains.copy_directory()


### PR DESCRIPTION
Found when creating a new Bazel module repository via `bazel-contrib/rules-template`, updating the libs to their latest version, and testing in CI with Bazel `8.0.0rc1`.

That generates an error such as:
```
ERROR: Traceback (most recent call last):
        File "${BAZEL_DIR}/external/stardoc+/stardoc/BUILD", line 72, column 16, in <toplevel>
                srcs = glob(["*.jar"]),
Error in glob: glob pattern '*.jar' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
ERROR: ${REPO}/docs/BUILD.bazel:5:23: Target '@@stardoc+//stardoc:templates/markdown_tables/module_extension.vm' contains an error and its package is in error and referenced by '//docs:rules'
```

This was fixed by the [`0.7.1` release of `bazelbuild/stardoc`](https://github.com/bazelbuild/stardoc/releases/tag/0.7.1).