### PR TITLE
docs: warn about gzip timestamps

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -17,6 +17,13 @@ We also provide full control for tar'ring binaries including their runfiles.
 The `tar` binary is hermetic and fully statically-linked.
 It is fetched as a toolchain from https://github.com/aspect-build/bsdtar-prebuilt.
 
+## Important Note
+
+When using `compress = "gzip"` its important to disable the non-deterministic time header by providing the `--options=gzip:!timestamp` option.
+
+See: https://datatracker.ietf.org/doc/html/rfc1952#page-5
+See: https://github.com/bazel-contrib/bazel-lib/issues/783
+
 ## Examples
 
 See the [`tar` tests](/lib/tests/tar/BUILD.bazel) for examples of usage.

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -15,6 +15,13 @@ We also provide full control for tar'ring binaries including their runfiles.
 The `tar` binary is hermetic and fully statically-linked.
 It is fetched as a toolchain from https://github.com/aspect-build/bsdtar-prebuilt.
 
+## Important Note
+
+When using `compress = "gzip"` its important to disable the non-deterministic time header by providing the `--options=gzip:!timestamp` option.
+
+See: https://datatracker.ietf.org/doc/html/rfc1952#page-5
+See: https://github.com/bazel-contrib/bazel-lib/issues/783
+
 ## Examples
 
 See the [`tar` tests](/lib/tests/tar/BUILD.bazel) for examples of usage.


### PR DESCRIPTION
For now we will just warn people to do the right thing. 
See: https://github.com/bazel-contrib/bazel-lib/issues/783