### PR TITLE
docs: Update jq docs to show correct escaping

### DIFF
--- a/docs/jq.md
+++ b/docs/jq.md
@@ -91,7 +91,7 @@ jq(
         "--raw-input",
         "--slurp",
     ],
-    filter = "{ deps: split("\n") | map(select(. | length > 0)) }",
+    filter = "{ deps: split(\"\\n\") | map(select(. | length > 0)) }",
 )
 ```
 

--- a/lib/jq.bzl
+++ b/lib/jq.bzl
@@ -89,7 +89,7 @@ jq(
         "--raw-input",
         "--slurp",
     ],
-    filter = "{ deps: split(\"\\n\") | map(select(. | length > 0)) }",
+    filter = "{ deps: split(\\\"\\\\n\\\") | map(select(. | length > 0)) }",
 )
 ```
 


### PR DESCRIPTION
As seen here: https://github.com/bazel-contrib/bazel-lib/blob/31e6c76b7d2e91657913232ec33da6a8b6ace90b/lib/jq.bzl#L87

The docs show the incorrect escaping sequence.