### PR TITLE
fix: honor umask in write_source_file

### DIFF
--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -221,21 +221,21 @@ mkdir -p "$(dirname "$out")"
 if [[ -f "$in" ]]; then
     echo "Copying file $in to $out in $PWD"
     # in case `cp` from previous command was terminated midway which can result in read-only files/dirs
-    chmod -R ug+w "$out" > /dev/null 2>&1 || true
+    chmod -R +w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"
     cp -f "$in" "$out"
     # cp should make the file writable but call chmod anyway as a defense in depth
-    chmod ug+w "$out"
+    chmod +w "$out"
     # cp should make the file not-executable but set the desired execute bit in both cases as a defense in depth
     {executable_file}
 else
     echo "Copying directory $in to $out in $PWD"
     # in case `cp` from previous command was terminated midway which can result in read-only files/dirs
-    chmod -R ug+w "$out" > /dev/null 2>&1 || true
+    chmod -R +w "$out" > /dev/null 2>&1 || true
     rm -Rf "$out"/{{*,.[!.]*}}
     mkdir -p "$out"
     cp -fRL "$in"/. "$out"
-    chmod -R ug+w "$out"
+    chmod -R +w "$out"
     {executable_dir}
 fi
 """.format(


### PR DESCRIPTION
In write_source_file, the output file should honor the current umask when marking files as writable. Not doing so ends up in situations where the file is e.g. created as 664 when initially generated with `write_source_file` but then a git clone/checkout/subtree would create it as 644. This can cause confusion to the user, and might unnecessarily be treated as a file change by some tooling.

From `man 2 chmod`, describing `chmod [who]+[perm]`:

> If no value is supplied for [who], each permission bit specified in
> [perm], for which the corresponding bit in the file mode creation mask
> (see umask(2)) is clear, is set.