### PR TITLE
fix: Disable the non-deterministic time header when using gzip compression

### DIFF
--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -133,6 +133,7 @@ def _add_compression_args(compress, args):
         args.add("--compress")
     if compress == "gzip":
         args.add("--gzip")
+	args.add("--options=gzip:!timestamp")
     if compress == "lrzip":
         args.add("--lrzip")
     if compress == "lzma":


### PR DESCRIPTION
Maybe a naive approach since I don't know the lib very well. I found https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#important-note and could not come up with any situation where a user does want to have a non-deterministic tarball.