### PR TITLE
fix: Disable the non-deterministic time header when using gzip compression

### DIFF
--- a/docs/tar.md
+++ b/docs/tar.md
@@ -223,3 +223,5 @@ tar_lib.mtree_implementation(<a href="#tar_lib.mtree_implementation-ctx">ctx</a>
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="tar_lib.mtree_implementation-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
+
+

--- a/docs/tar.md
+++ b/docs/tar.md
@@ -17,13 +17,6 @@ We also provide full control for tar'ring binaries including their runfiles.
 The `tar` binary is hermetic and fully statically-linked.
 It is fetched as a toolchain from https://github.com/aspect-build/bsdtar-prebuilt.
 
-## Important Note
-
-When using `compress = "gzip"` its important to disable the non-deterministic time header by providing the `--options=gzip:!timestamp` option.
-
-See: https://datatracker.ietf.org/doc/html/rfc1952#page-5
-See: https://github.com/bazel-contrib/bazel-lib/issues/783
-
 ## Examples
 
 See the [`tar` tests](/lib/tests/tar/BUILD.bazel) for examples of usage.
@@ -230,5 +223,3 @@ tar_lib.mtree_implementation(<a href="#tar_lib.mtree_implementation-ctx">ctx</a>
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="tar_lib.mtree_implementation-ctx"></a>ctx |  <p align="center"> - </p>   |  none |
-
-

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -133,6 +133,7 @@ def _add_compression_args(compress, args):
         args.add("--compress")
     if compress == "gzip":
         args.add("--gzip")
+	args.add("--options=gzip:!timestamp")
     if compress == "lrzip":
         args.add("--lrzip")
     if compress == "lzma":

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -133,7 +133,7 @@ def _add_compression_args(compress, args):
         args.add("--compress")
     if compress == "gzip":
         args.add("--gzip")
-	args.add("--options=gzip:!timestamp")
+        args.add("--options=gzip:!timestamp")
     if compress == "lrzip":
         args.add("--lrzip")
     if compress == "lzma":
@@ -278,7 +278,6 @@ def _configured_unused_inputs_file(ctx, srcs, keep):
     )
 
     return unused_inputs
-
 
 # TODO(3.0): Access field directly after minimum bazel_compatibility advanced to or beyond v7.0.0.
 def _repo_mapping_manifest(files_to_run):

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -133,7 +133,7 @@ def _add_compression_args(compress, args):
         args.add("--compress")
     if compress == "gzip":
         args.add("--gzip")
-        args.add("--options=gzip:!timestamp")
+        args.add("--options=gzip:!timestamp")  # See https://datatracker.ietf.org/doc/html/rfc1952#page-5 why this option
     if compress == "lrzip":
         args.add("--lrzip")
     if compress == "lzma":

--- a/lib/tar.bzl
+++ b/lib/tar.bzl
@@ -15,13 +15,6 @@ We also provide full control for tar'ring binaries including their runfiles.
 The `tar` binary is hermetic and fully statically-linked.
 It is fetched as a toolchain from https://github.com/aspect-build/bsdtar-prebuilt.
 
-## Important Note
-
-When using `compress = "gzip"` its important to disable the non-deterministic time header by providing the `--options=gzip:!timestamp` option.
-
-See: https://datatracker.ietf.org/doc/html/rfc1952#page-5
-See: https://github.com/bazel-contrib/bazel-lib/issues/783
-
 ## Examples
 
 See the [`tar` tests](/lib/tests/tar/BUILD.bazel) for examples of usage.


### PR DESCRIPTION
Maybe a naive approach since I don't know the lib very well. I found https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md#important-note and could not come up with any situation where a user does want to have a non-deterministic tarball.

Replace https://github.com/bazel-contrib/bazel-lib/pull/987

Closes #783

---

I was also thinking about adding an integration test for this such as building a tarball twice and make sure the second one is cached. Open for other suggestions though.