### PR TITLE
fix(bats_test): use env var rather than symbolic link

### DIFF
--- a/lib/private/bats.bzl
+++ b/lib/private/bats.bzl
@@ -27,8 +27,9 @@ export BATS_LIB_PATH=$(
 export BATS_TEST_TIMEOUT="$TEST_TIMEOUT"
 export BATS_TMPDIR="$TEST_TMPDIR"
 
-ln -s "$XML_OUTPUT_FILE" "$(dirname "$XML_OUTPUT_FILE")/report.xml"
-exec $bats {tests} --report-formatter junit --output "$(dirname $XML_OUTPUT_FILE)" "$@"
+# Undocumented: bats can write the JUnit report to any file we specify:
+# https://github.com/bats-core/bats-core/blob/b640ec3cf2c7c9cfc9e6351479261186f76eeec8/libexec/bats-core/bats#L400
+BATS_REPORT_FILENAME="$(basename $XML_OUTPUT_FILE)" exec $bats {tests} --report-formatter junit --output "$(dirname $XML_OUTPUT_FILE)" "$@"
 """
 
 _ENV_SET = """export {key}=\"{value}\""""


### PR DESCRIPTION
This allows it to work on Windows as well.

Fixes red main build following #982 
(note that the CI setup for this repo saves GHA quota by not running tests on Windows for all PRs, only when they come from a branch with 'windows' in the name)

Tested by using a little-known feature where Bazel can report the test case names:

```
$ bazel test lib/tests/bats:basic --test_summary=detailed
INFO: Analyzed target //lib/tests/bats:basic (3 packages loaded, 947 targets configured).
INFO: Found 1 test target...
Target //lib/tests/bats:basic up-to-date:
  bazel-bin/lib/tests/bats/basic_bats.sh
INFO: Elapsed time: 0.399s, Critical Path: 0.21s
INFO: 3 processes: 2 internal, 1 linux-sandbox.
INFO: Build completed successfully, 3 total actions
//lib/tests/bats:basic                                                   PASSED in 0.2s
    PASSED  basic.bats.assert_output() check for existence (0.0s)
Test cases: finished with 1 passing and 0 failing out of 1 test cases
```