### PR TITLE
chore: rename rules_go

### DIFF
--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -2,7 +2,7 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 index e63fa5b..9d78a88 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -50,19 +50,19 @@ use_repo(host, "aspect_bazel_lib_host")
+@@ -50,18 +50,18 @@ use_repo(host, "aspect_bazel_lib_host")
  bazel_dep(
      name = "gazelle",
      version = "0.36.0",
@@ -12,7 +12,6 @@ index e63fa5b..9d78a88 100644
  bazel_dep(
      name = "rules_go",
      version = "0.46.0",
-     repo_name = "io_bazel_rules_go",
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,
  )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,7 +52,6 @@ bazel_dep(
 bazel_dep(
     name = "rules_go",
     version = "0.46.0",
-    repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )
 

--- a/e2e/copy_to_directory/WORKSPACE
+++ b/e2e/copy_to_directory/WORKSPACE
@@ -15,7 +15,7 @@ register_copy_to_directory_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
+    name = "rules_go",
     sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
@@ -30,7 +30,7 @@ load("@aspect_bazel_lib//:deps.bzl", "go_dependencies")
 
 go_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/e2e/external_copy_to_directory/WORKSPACE
+++ b/e2e/external_copy_to_directory/WORKSPACE
@@ -13,7 +13,7 @@ aspect_bazel_lib_dependencies()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
+    name = "rules_go",
     sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
@@ -28,7 +28,7 @@ load("@aspect_bazel_lib//:deps.bzl", "go_dependencies")
 
 go_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/e2e/external_copy_to_directory/app/WORKSPACE
+++ b/e2e/external_copy_to_directory/app/WORKSPACE
@@ -16,7 +16,7 @@ aspect_bazel_lib_dependencies()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
+    name = "rules_go",
     sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
@@ -31,7 +31,7 @@ load("@aspect_bazel_lib//:deps.bzl", "go_dependencies")
 
 go_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -6,7 +6,7 @@ load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:yq.bzl", "yq")
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@rules_go//go:def.bzl", "go_test")
 
 # Validate that JQ works and resolves its toolchain
 jq(
@@ -121,9 +121,6 @@ go_test(
     name = "test_preserve_mtime",
     size = "small",
     srcs = ["test_preserve_mtime.go"],
-    deps = [
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
-    ],
     data = [
         "d",
         ":copy_directory_mtime_case",
@@ -135,5 +132,12 @@ go_test(
     #   bazel test :test_preserve_mtime # This test should pass
     #   touch d/1 # Update the mtime, in the CI environment this is done with the SCM integration.
     #   bazel test :test_preserve_mtime # This test now fails
-    tags = ["no-remote", "external", "manual"],
+    tags = [
+        "external",
+        "manual",
+        "no-remote",
+    ],
+    deps = [
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -5,4 +5,4 @@ local_path_override(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
-bazel_dep(name = "rules_go",  version = "0.50.1", repo_name = "io_bazel_rules_go", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.50.1", dev_dependency = True)

--- a/e2e/smoke/WORKSPACE
+++ b/e2e/smoke/WORKSPACE
@@ -13,7 +13,7 @@ aspect_bazel_lib_register_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
+    name = "rules_go",
     sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
@@ -28,7 +28,7 @@ load("@aspect_bazel_lib//:deps.bzl", "go_dependencies")
 
 go_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//lib:diff_test.bzl", "diff_test")
 load(
     "//lib:transitions.bzl",
@@ -22,7 +22,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
-        "@io_bazel_rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
+        "@rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
     ],
 )
 
@@ -31,7 +31,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
-        "@io_bazel_rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
+        "@rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
     ],
 )
 
@@ -137,7 +137,10 @@ platform_transition_test(
     name = "transitioned_go_test_x86_64",
     binary = ":test_transition_test",
     # only run this test on an x86_64 host
-    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == ["@platforms//cpu:x86_64", "@platforms//os:linux"] else ["@platforms//:incompatible"],
+    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ] else ["@platforms//:incompatible"],
     target_platform = "x86_64_linux",
 )
 
@@ -145,7 +148,10 @@ platform_transition_test(
     name = "transitioned_go_test_arm64",
     binary = ":test_transition_test",
     # only run this test on an x86_64 host
-    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == ["@platforms//cpu:aarch64", "@platforms//os:linux"] else ["@platforms//:incompatible"],
+    target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ] else ["@platforms//:incompatible"],
     target_platform = "arm64_linux",
 )
 

--- a/tools/common/BUILD.bazel
+++ b/tools/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "common",
@@ -11,10 +11,10 @@ go_library(
     importpath = "github.com/bazel-contrib/bazel-lib/tools/common",
     visibility = ["//visibility:public"],
     deps = select({
-        "@io_bazel_rules_go//go/platform:darwin": [
+        "@rules_go//go/platform:darwin": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:ios": [
+        "@rules_go//go/platform:ios": [
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/tools/copy_directory/BUILD.bazel
+++ b/tools/copy_directory/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "copy_directory_lib",

--- a/tools/copy_to_directory/BUILD.bazel
+++ b/tools/copy_to_directory/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "copy_to_directory_lib",

--- a/tools/expand_template/BUILD.bazel
+++ b/tools/expand_template/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "expand_template_lib",

--- a/tools/release/release.bzl
+++ b/tools/release/release.bzl
@@ -1,7 +1,7 @@
 """This module provides the macros for performing a release.
 """
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_go//go:def.bzl", "go_binary")
 load(":hashes.bzl", "hashes")
 
 PLATFORMS = [


### PR DESCRIPTION
io_bazel_rules_go was the old name and retired a while ago.

Fixes #990