### PR TITLE
chore(deps): Enable renovate for pre-commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":dependencyDashboard",
+    ":enablePreCommit",
     ":semanticPrefixFixDepsChoreOthers",
     "group:monorepos",
     "group:recommended",


### PR DESCRIPTION
Renovate does not upgrade pre-commit hooks by default. I think, we should also keep them up to date.

Just enabling it will create a separate PR per hook. In case this becomes too noisy, we can also configure renovate to create a single PR updating all in one.