### PR TITLE
feat: Forward RunEnvironmentInfo if present

### DIFF
--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -10,7 +10,7 @@ Rules for working with transitions.
 platform_transition_binary(<a href="#platform_transition_binary-name">name</a>, <a href="#platform_transition_binary-basename">basename</a>, <a href="#platform_transition_binary-binary">binary</a>, <a href="#platform_transition_binary-target_platform">target_platform</a>)
 </pre>
 
-Transitions the binary to use the provided platform.
+Transitions the binary to use the provided platform. Will forward RunEnvironmentInfo
 
 **ATTRIBUTES**
 
@@ -51,7 +51,7 @@ Transitions the srcs to use the provided platform. The filegroup will contain ar
 platform_transition_test(<a href="#platform_transition_test-name">name</a>, <a href="#platform_transition_test-basename">basename</a>, <a href="#platform_transition_test-binary">binary</a>, <a href="#platform_transition_test-target_platform">target_platform</a>)
 </pre>
 
-Transitions the test to use the provided platform.
+Transitions the test to use the provided platform. Will forward RunEnvironmentInfo
 
 **ATTRIBUTES**
 

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -90,6 +90,9 @@ def _platform_transition_binary_impl(ctx):
         ),
     )
 
+    if RunEnvironmentInfo in binary:
+        result.append(binary[RunEnvironmentInfo])
+
     return result
 
 def _get_platform_transition_attrs(binary_cfg):
@@ -112,7 +115,7 @@ platform_transition_binary = rule(
     # intuitive output path (matching an untransitioned binary).
     attrs = _get_platform_transition_attrs(binary_cfg = _transition_platform),
     executable = True,
-    doc = "Transitions the binary to use the provided platform.",
+    doc = "Transitions the binary to use the provided platform. Will forward RunEnvironmentInfo",
 )
 
 platform_transition_test = rule(
@@ -123,5 +126,5 @@ platform_transition_test = rule(
     # the test action.
     cfg = _transition_platform,
     test = True,
-    doc = "Transitions the test to use the provided platform.",
+    doc = "Transitions the test to use the provided platform. Will forward RunEnvironmentInfo",
 )


### PR DESCRIPTION
Forward RunEnvironmentInfo if present, this is useful if the test we are transitioning requires environment variables.