### PR TITLE
fix(tar): allow --action_env to override LC_ALL

### DIFF
--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -333,7 +333,7 @@ def _tar_impl(ctx):
         mnemonic = "Tar",
         unused_inputs_list = unused_inputs_file,
         toolchain = "@aspect_bazel_lib//lib:tar_toolchain_type",
-	# Allow users to set --action_env=LC_ALL=C.UTF-8 for example,
+        # Allow users to set --action_env=LC_ALL=C.UTF-8 for example,
         # on systems where default locale is wrong.
         # See https://github.com/bazelbuild/bazel-central-registry/issues/2256
         use_default_shell_env = True,

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -333,6 +333,10 @@ def _tar_impl(ctx):
         mnemonic = "Tar",
         unused_inputs_list = unused_inputs_file,
         toolchain = "@aspect_bazel_lib//lib:tar_toolchain_type",
+	# Allow users to set --action_env=LC_ALL=C.UTF-8 for example,
+        # on systems where default locale is wrong.
+        # See https://github.com/bazelbuild/bazel-central-registry/issues/2256
+        use_default_shell_env = True,
     )
 
     # TODO(3.0): Always return a list of providers.


### PR DESCRIPTION
`bsdtar` will fail to extract archives with unicode characters in a filename, on systems where the default locale is `C` or some non-UTF value.

Users encounter this as strange extract failures, but only on a subset of the systems they work on; this is non-hermetic behavior.

Workaround https://github.com/bazelbuild/bazel-central-registry/issues/2256