### PR TITLE
feat: Add option to pass args to `diff` command in `diff_test` on Linux/MacOS

### DIFF
--- a/docs/diff_test.md
+++ b/docs/diff_test.md
@@ -15,7 +15,7 @@ See also: [rules_diff](https://gitlab.arm.com/bazel/rules_diff)
 ## diff_test
 
 <pre>
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-diff_args">diff_args</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">kwargs</a>)
 </pre>
 
 A test that compares two files.
@@ -31,6 +31,7 @@ The test succeeds if the files' contents match.
 | <a id="diff_test-name"></a>name |  The name of the test rule.   |  none |
 | <a id="diff_test-file1"></a>file1 |  Label of the file to compare to <code>file2</code>.   |  none |
 | <a id="diff_test-file2"></a>file2 |  Label of the file to compare to <code>file1</code>.   |  none |
+| <a id="diff_test-diff_args"></a>diff_args |  Arguments to pass to the `diff` command. (Ignored on Windows)   |  `[]` |
 | <a id="diff_test-size"></a>size |  standard attribute for tests   |  `"small"` |
 | <a id="diff_test-kwargs"></a>kwargs |  The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.   |  none |
 

--- a/docs/write_source_files.md
+++ b/docs/write_source_files.md
@@ -123,7 +123,7 @@ Provider for write_source_file targets
 <pre>
 write_source_file(<a href="#write_source_file-name">name</a>, <a href="#write_source_file-in_file">in_file</a>, <a href="#write_source_file-out_file">out_file</a>, <a href="#write_source_file-executable">executable</a>, <a href="#write_source_file-additional_update_targets">additional_update_targets</a>,
                   <a href="#write_source_file-suggested_update_target">suggested_update_target</a>, <a href="#write_source_file-diff_test">diff_test</a>, <a href="#write_source_file-diff_test_failure_message">diff_test_failure_message</a>,
-                  <a href="#write_source_file-file_missing_failure_message">file_missing_failure_message</a>, <a href="#write_source_file-check_that_out_file_exists">check_that_out_file_exists</a>, <a href="#write_source_file-kwargs">kwargs</a>)
+                  <a href="#write_source_file-file_missing_failure_message">file_missing_failure_message</a>, <a href="#write_source_file-diff_args">diff_args</a>, <a href="#write_source_file-check_that_out_file_exists">check_that_out_file_exists</a>, <a href="#write_source_file-kwargs">kwargs</a>)
 </pre>
 
 Write a file or directory to the source tree.
@@ -147,6 +147,7 @@ To disable the exists check and up-to-date test set `diff_test` to `False`.
 | <a id="write_source_file-diff_test"></a>diff_test |  Test that the source tree file or directory exist and is up to date.   |  `True` |
 | <a id="write_source_file-diff_test_failure_message"></a>diff_test_failure_message |  Text to print when the diff test fails, with templating options for relevant targets.<br><br>Substitutions are performed on the failure message, with the following substitutions being available:<br><br>`{{DEFAULT_MESSAGE}}`: Prints the default error message, listing the target(s) that   may be run to update the file(s).<br><br>`{{TARGET}}`: The target to update the individual file that does not match in the   diff test.<br><br>`{{SUGGESTED_UPDATE_TARGET}}`: The suggested_update_target if specified.   |  `"{{DEFAULT_MESSAGE}}"` |
 | <a id="write_source_file-file_missing_failure_message"></a>file_missing_failure_message |  Text to print when the output file is missing. Subject to the same substitutions as diff_test_failure_message.   |  `"{{DEFAULT_MESSAGE}}"` |
+| <a id="write_source_file-diff_args"></a>diff_args |  Arguments to pass to the `diff` command. (Ignored on Windows)   |  `[]` |
 | <a id="write_source_file-check_that_out_file_exists"></a>check_that_out_file_exists |  Test that the output file exists and print a helpful error message if it doesn't.<br><br>If `True`, the output file or directory must be in the same containing Bazel package as the target since the underlying mechanism for this check is limited to files in the same Bazel package.   |  `True` |
 | <a id="write_source_file-kwargs"></a>kwargs |  Other common named parameters such as `tags` or `visibility`   |  none |
 

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -104,6 +104,7 @@ bzl_library(
     deps = [
         ":directory_path",
         "//lib:utils",
+        "@bazel_skylib//lib:shell",
     ],
 )
 

--- a/lib/private/diff_test_tmpl.sh
+++ b/lib/private/diff_test_tmpl.sh
@@ -72,11 +72,11 @@ if [[ ! "$DF1" ]] && [[ "$DF2" ]]; then
   exit 1
 fi
 if [[ "$DF1" ]] || [[ "$DF2" ]]; then
-  if ! diff -r "$RF1" "$RF2"; then
+  if ! diff {diff_args} -r "$RF1" "$RF2"; then
     fail "directories \"{file1}\" and \"{file2}\" differ. {fail_msg}"
   fi
 else
-  if ! diff "$RF1" "$RF2"; then
+  if ! diff {diff_args} "$RF1" "$RF2"; then
     fail "files \"{file1}\" and \"{file2}\" differ. {fail_msg}"
   fi
 fi

--- a/lib/private/write_source_file.bzl
+++ b/lib/private/write_source_file.bzl
@@ -22,6 +22,7 @@ def write_source_file(
         diff_test = True,
         diff_test_failure_message = "{{DEFAULT_MESSAGE}}",
         file_missing_failure_message = "{{DEFAULT_MESSAGE}}",
+        diff_args = [],
         check_that_out_file_exists = True,
         **kwargs):
     """Write a file or directory to the source tree.
@@ -65,6 +66,8 @@ def write_source_file(
 
         file_missing_failure_message: Text to print when the output file is missing. Subject to the same
              substitutions as diff_test_failure_message.
+
+        diff_args: Arguments to pass to the `diff` command. (Ignored on Windows)
 
         check_that_out_file_exists: Test that the output file exists and print a helpful error message if it doesn't.
 
@@ -177,6 +180,7 @@ To update *only* this file, run:
             file1 = in_file,
             file2 = out_file,
             failure_message = message,
+            diff_args = diff_args,
             **kwargs
         )
 


### PR DESCRIPTION
This makes it possible to pass extra arguments to the diff command that is run in a `diff_test()`.

~When running `bazel run @@//docs:update` I get a diff in all documents to add example `load()` statements. This was added in [stardoc 0.7.0](https://github.com/bazelbuild/stardoc/releases/tag/0.7.0). I'm not sure how it is leaking in to my local environment. :thinking:~