### PR TITLE
chore: remove #keeps

### DIFF
--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -271,6 +271,7 @@ bzl_library(
     srcs = [
         "platform_utils.bzl",
         "@local_config_platform//:constraints.bzl",
+        "@platforms//host:constraints.bzl",  # keep
     ],
     visibility = ["//lib:__subpackages__"],
 )

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -270,12 +270,9 @@ bzl_library(
     name = "platform_utils",
     srcs = [
         "platform_utils.bzl",
-        "@host_platform//:constraints.bzl",  # keep
-        "@local_config_platform//:constraints.bzl",  # keep
-        "@platforms//host:constraints.bzl",  # keep
+        "@local_config_platform//:constraints.bzl",
     ],
     visibility = ["//lib:__subpackages__"],
-    deps = [],  # keep
 )
 
 bzl_library(


### PR DESCRIPTION
Looks like the cleanup was missed in https://github.com/bazel-contrib/bazel-lib/pull/915/files

(It was suggested in this comment https://github.com/bazel-contrib/bazel-lib/pull/914/files#r1723515098 )

This seems to be breaking a downstream PR in rules_swc