### PR TITLE
feat: add riscv64 support to yq toolchain

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -186,7 +186,7 @@ Registers yq toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_yq_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  `"yq"` |
-| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  `"4.25.2"` |
+| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  `"4.45.1"` |
 | <a id="register_yq_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  `True` |
 
 

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -34,6 +34,12 @@ YQ_PLATFORMS = {
             "@platforms//cpu:s390x",
         ],
     ),
+    "linux_riscv64": struct(
+        compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:riscv64",
+        ],
+    ),
     "linux_ppc64le": struct(
         compatible_with = [
             "@platforms//os:linux",
@@ -50,7 +56,7 @@ YQ_PLATFORMS = {
 
 # Note: this is not the latest release, because it has significant breaking changes.
 # See https://github.com/bazel-contrib/bazel-lib/pull/421
-DEFAULT_YQ_VERSION = "4.25.2"
+DEFAULT_YQ_VERSION = "4.45.1"
 
 # https://github.com/mikefarah/yq/releases
 #
@@ -61,6 +67,16 @@ DEFAULT_YQ_VERSION = "4.25.2"
 # Alternatively, you can compute them manually by running
 # `shasum -b -a 384 [downloaded file] | awk '{ print $1 }' | xxd -r -p | base64`
 YQ_VERSIONS = {
+    "4.45.1": {
+        "darwin_amd64": "sha384-ZoEgzfCLmDk7eoKdJSoq/nny1iX3Cq9mMJ3gnPZ2ejhKMxSgHUQIa7MREToxYl6Z",
+        "darwin_arm64": "sha384-nHYFqoarTzGba/XtpN8N3U0X9hMTg64Vn7XZ8yiF2cbJFdY3VWFVw80vsg/JXaOg",
+        "linux_amd64": "sha384-hkMtSRoq1GZKoH9C6OesKhgFLtkcm91wUD2W7L/xlAOS7jZbii23uEMHApo5r7Qs",
+        "linux_arm64": "sha384-4N6BWZ7ExxmnfqXGGTo7Szi73kJfbgMaUXW0FT10kcy2fNW0VbjBBAfClC14lES2",
+        "linux_s390x": "sha384-DRzz5Sb3JvwDVjQWGVto3Eh7a7tNQmwXZtMTQy+SidCYGQ2sLA3SQqqsQicNaD8A",
+        "linux_riscv64": "sha384-/4wDvlLP7f3lvEU/hrCa6wcGLzj8z1PYkWlULxIWHGn65Ai5xnI+Dp21VnM7iyi3",
+        "linux_ppc64le": "sha384-pnzDz7jn4b+1wOeasaEU6q5ASQhZw0Uz6sEehzpztqQglU6ynTkS8n4Nw/oqG5y9",
+        "windows_amd64": "sha384-P5c1L9KPhkLdByJ3G8IL3ouwNojoHSDDz6N851RRXxK1Y+ssYKPO/cbQzjQnpKvc",
+    },
     "4.33.3": {
         "darwin_amd64": "sha384-IJhMHD71yq+OR8AHFPfZr3XVpFlG2ZAfcexDKojtSLcCMV1pw0X2jza4qFUZiKEt",
         "darwin_arm64": "sha384-euQkz1Bu/dFuJoRgG4xIh9BhP2RvOceTDPSY8EzSIM5xykbMkwDNhr1PtCcUF5ye",

--- a/lib/tests/yq/BUILD.bazel
+++ b/lib/tests/yq/BUILD.bazel
@@ -116,7 +116,10 @@ diff_test(
 yq(
     name = "case_convert_json_to_yaml",
     srcs = ["//lib/tests/jq:a_pretty.json"],
-    args = ["-P"],
+    args = [
+        "-P",
+        "-oy",
+    ],
     expression = ".",
 )
 
@@ -129,7 +132,10 @@ diff_test(
 yq(
     name = "case_convert_json_to_yaml_otherextension",
     srcs = ["a.dealerschoice"],
-    args = ["-P"],
+    args = [
+        "-P",
+        "-oy",
+    ],
     expression = ".",
 )
 
@@ -361,7 +367,10 @@ yq(
         "//lib/tests/jq:a.json",
         "//lib/tests/jq:b.json",
     ],
-    args = ["-P"],
+    args = [
+        "-P",
+        "-oy",
+    ],
     expression = ". as $item ireduce ({}; . * $item )",
 )
 

--- a/lib/tests/yq/sample.yaml
+++ b/lib/tests/yq/sample.yaml
@@ -1,3 +1,4 @@
++p_xml: version="1.0" encoding="UTF-8"
 cat:
   says: meow
   legs: "4"

--- a/tools/yq_mirror_release.sh
+++ b/tools/yq_mirror_release.sh
@@ -21,7 +21,7 @@ chmod u+x extract-checksum.sh
 
 # Extract the checksums and output a starlark map entry
 echo "\"$version\": {"
-platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,ppc64le} windows_amd64)
+platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,riscv64,ppc64le} windows_amd64)
 for release in ${platforms[@]}; do
   artifact=$release
   if [[ $release == windows* ]]; then


### PR DESCRIPTION
This patch adds riscv64 support to yq toolchain. 

The last version 4.33.3 in `lib/private/yq_toolchain.bzl` does not have riscv64 binary releases in yq repository so I added the latest release to it.