### PR TITLE
feat: publish release attestations

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish
+on:
+  # Run the publish workflow after a successful release
+  # Will be triggered from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: bazel-contrib/bazel-central-registry
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           subject-path: artifacts/*
   release:
     needs: build
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@443541da08f32816d70070ea30b5b0ee53d5e53d
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.1
     with:
       release_files: |
         artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - "v*.*.*"
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
 jobs:
   build:
     # Go cross-compilation works from linux -> any platform
@@ -26,22 +30,22 @@ jobs:
           name: artifacts
           path: artifacts/
           retention-days: 1
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: artifacts/*
   release:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # Fetch the built artifacts from build jobs above and extract into
-      # ${GITHUB_WORKSPACE}/artifacts/*
-      - uses: actions/download-artifact@v4
-      - name: Prepare workspace snippet
-        run: .github/workflows/release_prep.sh > release_notes.txt
-      - uses: softprops/action-gh-release@v2
-        with:
-          # Use GH feature to populate the changelog automatically
-          generate_release_notes: true
-          files: |
-            artifacts/*
-            bazel-lib-*.tar.gz
-          body_path: release_notes.txt
-          fail_on_unmatched_files: true
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@443541da08f32816d70070ea30b5b0ee53d5e53d
+    with:
+      release_files: |
+        artifacts/*
+        bazel-lib-*.tar.gz
+      prerelease: false
+      tag_name: ${{ github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Allows users to trust that release artifacts are not tampered