### PR TITLE
fix(release): upgrade release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build Go Binaries
         env:
           # NB: this variable is read by tools/release/copy_release_artifacts.sh
-          DEST: artifacts
+          DEST: binaries
         run: |
           rm -rf ${{ env.DEST }}
           mkdir -p ${{ env.DEST }}
@@ -27,18 +27,15 @@ jobs:
             run --config=release //tools/release:copy_release_artifacts
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
-          path: artifacts/
+          name: go-binaries
+          path: binaries/
           retention-days: 1
-      - uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: artifacts/*
   release:
     needs: build
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.1
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: |
-        artifacts/*
+        binaries/*
         bazel-lib-*.tar.gz
       prerelease: false
       tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Also rename our upload to 'binaries' to avoid colliding with default upload name 'artifacts'