### PR TITLE
fix(release): missed a spot in last commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Build Go Binaries
         env:
           # NB: this variable is read by tools/release/copy_release_artifacts.sh
+          # and must match the path in release_prep.sh under RELEASED_BINARY_INTEGRITY
           DEST: binaries
         run: |
           rm -rf ${{ env.DEST }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -30,7 +30,7 @@ RELEASED_BINARY_INTEGRITY = $(
   jq \
     --from-file .github/workflows/integrity.jq \
     --slurp \
-    --raw-input artifacts/*.sha256
+    --raw-input binaries/*.sha256
 )
 EOF
 


### PR DESCRIPTION
Not ready to merge, as there's also a problem with https://github.com/bazel-contrib/bazel-lib/releases/tag/v2.15.1 missing the binaries