### PR TITLE
fix(release): name of folder containing binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: |
-        binaries/*
+        go-binaries/*
         bazel-lib-*.tar.gz
       prerelease: false
       tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
The binaries get downloaded to the `go-binaries` folder as `download-artifact` defaults to the name of the GHA artifact.