### PR TITLE
fix(release): yet another spot that's wrong

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -30,7 +30,7 @@ RELEASED_BINARY_INTEGRITY = $(
   jq \
     --from-file .github/workflows/integrity.jq \
     --slurp \
-    --raw-input binaries/*.sha256
+    --raw-input go-binaries/*.sha256
 )
 EOF
 


### PR DESCRIPTION
v2.15.2 published with an empty dict in tools/integrity.bzl