### PR TITLE
feat(mtree_mutate): Adding Support for Group / GID to mtree_mutate

### DIFF
--- a/lib/private/modify_mtree.awk
+++ b/lib/private/modify_mtree.awk
@@ -88,7 +88,7 @@ function make_relative_link(path1, path2, i, common, target, relative_path, back
     }
 
     if (group != "") {
-        sub(/uid=[0-9\.]+/, "uid=" group)
+        sub(/gid=[0-9\.]+/, "gid=" group)
     }
 
     if (package_dir != "") {

--- a/lib/private/modify_mtree.awk
+++ b/lib/private/modify_mtree.awk
@@ -91,6 +91,10 @@ function make_relative_link(path1, path2, i, common, target, relative_path, back
         sub(/gid=[0-9\.]+/, "gid=" group)
     }
 
+    if (groupname != "") {
+        sub(/gname=[^ ]+/, "gname=" groupname)
+    }
+
     if (package_dir != "") {
         sub(/^/, package_dir "/")
     }

--- a/lib/private/modify_mtree.awk
+++ b/lib/private/modify_mtree.awk
@@ -87,6 +87,10 @@ function make_relative_link(path1, path2, i, common, target, relative_path, back
         sub(/uname=[^ ]+/, "uname=" ownername)
     }
 
+    if (group != "") {
+        sub(/uid=[0-9\.]+/, "uid=" group)
+    }
+
     if (package_dir != "") {
         sub(/^/, package_dir "/")
     }

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -509,6 +509,8 @@ def _mtree_mutate_impl(ctx):
 
     if ctx.attr.owner:
         args.add("-v owner={}".format(ctx.attr.owner))
+    if ctx.attr.group:
+        args.add("-v group={}".format(ctx.attr.group))
     if ctx.attr.ownername:
         args.add("-v ownername={}".format(ctx.attr.ownername))
     if ctx.attr.strip_prefix:

--- a/lib/private/tar.bzl
+++ b/lib/private/tar.bzl
@@ -169,6 +169,12 @@ _mutate_mtree_attrs = {
     "ownername": attr.string(
         doc = "Specifies the name of the owner of the files in the tar archive. Used alongside 'owner'.",
     ),
+    "group": attr.string(
+        doc = "Specifies the numeric group ID (GID) for the group owner of the files in the tar archive.",
+    ),
+    "groupname": attr.string(
+        doc = "Specifies the name of the group of the files in the tar archive. Used alongside 'group'.",
+    ),
     "out": attr.output(
         doc = "The output of the mutation, a new mtree file.",
     ),
@@ -509,10 +515,12 @@ def _mtree_mutate_impl(ctx):
 
     if ctx.attr.owner:
         args.add("-v owner={}".format(ctx.attr.owner))
-    if ctx.attr.group:
-        args.add("-v group={}".format(ctx.attr.group))
     if ctx.attr.ownername:
         args.add("-v ownername={}".format(ctx.attr.ownername))
+    if ctx.attr.group:
+        args.add("-v group={}".format(ctx.attr.group))
+    if ctx.attr.groupname:
+        args.add("-v groupname={}".format(ctx.attr.groupname))
     if ctx.attr.strip_prefix:
         args.add("-v strip_prefix={}".format(ctx.attr.strip_prefix))
     if ctx.attr.package_dir:

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -358,6 +358,8 @@ mtree_mutate(
     mtree = "source-casync.mtree",
     owner = "123",
     ownername = "fred",
+    group = "1000",
+    groupname = "vbatts",
 )
 
 diff_test(

--- a/lib/tests/tar/BUILD.bazel
+++ b/lib/tests/tar/BUILD.bazel
@@ -354,12 +354,12 @@ diff_test(
 
 mtree_mutate(
     name = "modified2",
+    group = "1000",
+    groupname = "vbatts",
     mtime = 946684740,  # 1999-12-31, 23:59
     mtree = "source-casync.mtree",
     owner = "123",
     ownername = "fred",
-    group = "1000",
-    groupname = "vbatts",
 )
 
 diff_test(


### PR DESCRIPTION
Adding bits to allow mtree_mutate to receive a group name or GID and update the file permissions to set `gid` for the tar file

example usage
```
mtree_mutate(
    name = "foo",
    mtree = "foo",
    owner = "65543",
    group = "65543",
)
```