### PR TITLE
feat: fix build for --incompatible_autoload_externally=

### DIFF
--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -5,13 +5,13 @@ index e63fa5b..9d78a88 100644
 @@ -50,19 +50,19 @@ use_repo(host, "aspect_bazel_lib_host")
  bazel_dep(
      name = "gazelle",
-     version = "0.36.0",
+     version = "0.40.0",
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,
  )
  bazel_dep(
      name = "rules_go",
-     version = "0.46.0",
+     version = "0.51.0",
      repo_name = "io_bazel_rules_go",
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "stardoc", version = "0.6.2")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 
 # TODO(3.0): remove this back-compat
 bazel_dep(name = "tar.bzl", version = "0.2.1")
@@ -48,12 +49,12 @@ register_toolchains(
 
 bazel_dep(
     name = "gazelle",
-    version = "0.36.0",
+    version = "0.40.0",
     # In released versions: dev_dependency = True
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.46.0",
+    version = "0.51.0",
     repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )

--- a/e2e/external_copy_to_directory/app/BUILD.bazel
+++ b/e2e/external_copy_to_directory/app/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -236,6 +236,7 @@ bzl_library(
         ":utils",
         "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:write_file",
+        "@rules_shell//shell:rules_bzl",
     ],
 )
 

--- a/lib/testing.bzl
+++ b/lib/testing.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//lib:diff_test.bzl", "diff_test")
 load("//lib:jq.bzl", "jq")
 load("//lib:params_file.bzl", "params_file")
@@ -38,7 +39,7 @@ def assert_contains(name, actual, expected, size = "small", **kwargs):
         ],
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [test_sh],
         args = ["$(rootpath %s)" % expected_file, "$(rootpath %s)" % actual],
@@ -182,7 +183,7 @@ def assert_archive_contains(name, archive, expected, type = None, **kwargs):
         ],
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [script_name],
         args = ["$(rootpath %s)" % archive, "$(rootpath %s)" % expected_name],
@@ -237,7 +238,7 @@ def assert_directory_contains(name, directory, expected, **kwargs):
         ],
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [script_name],
         args = ["$(rootpath %s)" % directory, "$(rootpath %s)" % expected_name],

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//lib:expand_template.bzl", "expand_template")
 load("//lib:testing.bzl", "assert_contains")
 load(":base64_tests.bzl", "base64_test_suite")

--- a/lib/tests/copy_to_bin/BUILD.bazel
+++ b/lib/tests/copy_to_bin/BUILD.bazel
@@ -1,5 +1,6 @@
 "tests for copy_to_bin"
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//lib:copy_to_bin.bzl", "copy_to_bin")
 load("//lib:output_files.bzl", "output_files")
 

--- a/lib/tests/copy_to_directory/BUILD.bazel
+++ b/lib/tests/copy_to_directory/BUILD.bazel
@@ -1,5 +1,6 @@
 "tests for copy_to_directory"
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//lib:copy_directory.bzl", "copy_directory")
 load("//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//lib:diff_test.bzl", "diff_test")

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -1,6 +1,7 @@
 "tests for run_binary"
 
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//lib:diff_test.bzl", "diff_test")
 load("//lib:run_binary.bzl", "run_binary")

--- a/lib/tests/run_binary_expansions/BUILD.bazel
+++ b/lib/tests/run_binary_expansions/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//lib:run_binary.bzl", "run_binary")
 
 sh_binary(

--- a/lib/tests/stamping/BUILD.bazel
+++ b/lib/tests/stamping/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//lib:run_binary.bzl", "run_binary")
 load(":stamp_aware_rule.bzl", "my_stamp_aware_rule")
 

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//lib:diff_test.bzl", "diff_test")
 load(
     "//lib:transitions.bzl",

--- a/shlib/lib/BUILD.bazel
+++ b/shlib/lib/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+
 package(default_visibility = ["//visibility:public"])
 
 sh_library(

--- a/shlib/tests/lib_tests/assertions_tests/BUILD.bazel
+++ b/shlib/tests/lib_tests/assertions_tests/BUILD.bazel
@@ -1,3 +1,6 @@
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 sh_library(
     name = "assert_fail",
     testonly = True,

--- a/tools/release/BUILD.bazel
+++ b/tools/release/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(":release.bzl", "multi_platform_go_binaries")
 
 multi_platform_go_binaries(


### PR DESCRIPTION
This will become the default in bazel 9, and some packages (like ours) already set this flag to keep ahead of this. This change:
- adds a direct dependency on rules_shell, and changes all in-tree users to use it rather than `native.sh_*`
- bumps some dev dependencies to versions that have also performed this step, so bazel test works now, too. (gazelle and rules_go)