### PR TITLE
feat(diff_test): allow inline content for expected

### DIFF
--- a/docs/diff_test.md
+++ b/docs/diff_test.md
@@ -17,7 +17,7 @@ See also: [rules_diff](https://gitlab.arm.com/bazel/rules_diff)
 <pre>
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-diff_args">diff_args</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">**kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-content2">content2</a>, <a href="#diff_test-diff_args">diff_args</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">**kwargs</a>)
 </pre>
 
 A test that compares two files.
@@ -31,8 +31,9 @@ The test succeeds if the files' contents match.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="diff_test-name"></a>name |  The name of the test rule.   |  none |
-| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to <code>file2</code>.   |  none |
-| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to <code>file1</code>.   |  none |
+| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to <code>file2</code>.   |  `None` |
+| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to <code>file1</code>.   |  `None` |
+| <a id="diff_test-content2"></a>content2 |  List of lines that should be written in place of file2   |  `None` |
 | <a id="diff_test-diff_args"></a>diff_args |  Arguments to pass to the `diff` command. (Ignored on Windows)   |  `[]` |
 | <a id="diff_test-size"></a>size |  standard attribute for tests   |  `"small"` |
 | <a id="diff_test-kwargs"></a>kwargs |  The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.   |  none |

--- a/docs/diff_test.md
+++ b/docs/diff_test.md
@@ -17,7 +17,7 @@ See also: [rules_diff](https://gitlab.arm.com/bazel/rules_diff)
 <pre>
 load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-content2">content2</a>, <a href="#diff_test-diff_args">diff_args</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">**kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-diff_args">diff_args</a>, <a href="#diff_test-size">size</a>, <a href="#diff_test-kwargs">**kwargs</a>)
 </pre>
 
 A test that compares two files.
@@ -31,9 +31,8 @@ The test succeeds if the files' contents match.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="diff_test-name"></a>name |  The name of the test rule.   |  none |
-| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to <code>file2</code>.   |  `None` |
-| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to <code>file1</code>.   |  `None` |
-| <a id="diff_test-content2"></a>content2 |  List of lines that should be written in place of file2   |  `None` |
+| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to <code>file2</code>.   |  none |
+| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to <code>file1</code>, or a list of strings which are the lines to expect <code>file1</code> to contain.   |  none |
 | <a id="diff_test-diff_args"></a>diff_args |  Arguments to pass to the `diff` command. (Ignored on Windows)   |  `[]` |
 | <a id="diff_test-size"></a>size |  standard attribute for tests   |  `"small"` |
 | <a id="diff_test-kwargs"></a>kwargs |  The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.   |  none |

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -108,6 +108,7 @@ bzl_library(
         ":directory_path",
         "//lib:utils",
         "@bazel_skylib//lib:shell",
+        "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:write_file",
     ],
 )

--- a/lib/private/BUILD.bazel
+++ b/lib/private/BUILD.bazel
@@ -108,6 +108,7 @@ bzl_library(
         ":directory_path",
         "//lib:utils",
         "@bazel_skylib//lib:shell",
+        "@bazel_skylib//rules:write_file",
     ],
 )
 

--- a/lib/private/diff_test.bzl
+++ b/lib/private/diff_test.bzl
@@ -22,6 +22,7 @@ command (fc.exe) on Windows (no Bash is required).
 """
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(":directory_path.bzl", "DirectoryPathInfo")
 
@@ -113,7 +114,7 @@ _diff_test = rule(
     implementation = _diff_test_impl,
 )
 
-def diff_test(name, file1 = None, file2 = None, content2 = None, diff_args = [], size = "small", **kwargs):
+def diff_test(name, file1, file2, diff_args = [], size = "small", **kwargs):
     """A test that compares two files.
 
     The test succeeds if the files' contents match.
@@ -121,22 +122,19 @@ def diff_test(name, file1 = None, file2 = None, content2 = None, diff_args = [],
     Args:
       name: The name of the test rule.
       file1: Label of the file to compare to <code>file2</code>.
-      file2: Label of the file to compare to <code>file1</code>.
-      content2: List of lines that should be written in place of file2
+      file2: Label of the file to compare to <code>file1</code>, or a list of strings which are the lines to expect <code>file1</code> to contain.
       diff_args: Arguments to pass to the `diff` command. (Ignored on Windows)
       size: standard attribute for tests
       **kwargs: The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
     """
-    if int(bool(file2)) + int(content2 != None) != 1:
-        fail("Exactly one of file1 or content2 should be set")
-    if content2 != None:
-        content2_target = name + "_content2"
+    if types.is_list(file2):
+        write_file2_target = name + ".file2"
         write_file(
-            name = content2_target,
-            out = content2_target + ".txt",
-            content = content2,
+            name = write_file2_target,
+            out = write_file2_target + ".txt",
+            content = file2,
         )
-        file2 = content2_target
+        file2 = write_file2_target
 
     _diff_test(
         name = name,

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -80,20 +80,20 @@ genrule(
 
 diff_test(
     name = "test_x86",
-    content2 = [
+    file1 = ":for_x86_path",
+    file2 = [
         "lib/tests/transitions/linux_x86.txt",
         "",
     ],
-    file1 = ":for_x86_path",
 )
 
 diff_test(
     name = "test_arm",
-    content2 = [
+    file1 = ":for_arm_path",
+    file2 = [
         "lib/tests/transitions/linux_arm.txt",
         "",
     ],
-    file1 = ":for_arm_path",
 )
 
 go_binary(

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -79,34 +78,22 @@ genrule(
     cmd = "echo $(rootpath :for_arm) > $@",
 )
 
-write_file(
-    name = "expected_x86_path",
-    out = "expected_x86_path.txt",
-    content = [
+diff_test(
+    name = "test_x86",
+    content2 = [
         "lib/tests/transitions/linux_x86.txt",
         "",
     ],
-)
-
-write_file(
-    name = "expected_arm_path",
-    out = "expected_arm_path.txt",
-    content = [
-        "lib/tests/transitions/linux_arm.txt",
-        "",
-    ],
-)
-
-diff_test(
-    name = "test_x86",
     file1 = ":for_x86_path",
-    file2 = ":expected_x86_path",
 )
 
 diff_test(
     name = "test_arm",
+    content2 = [
+        "lib/tests/transitions/linux_arm.txt",
+        "",
+    ],
     file1 = ":for_arm_path",
-    file2 = ":expected_arm_path",
 )
 
 go_binary(


### PR DESCRIPTION
Shortens a lot of our BUILD files by avoiding an extra write_file call for literal content