### PR TITLE
chore: Exclude prettier hook from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "packageRules": [
     {
       "matchFiles": ["MODULE.bazel"],
+      "matchPackageNames": ["pre-commit/mirrors-prettier"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Renovate/pre-commit autoupdate will try to update to an alpha release which we don't want to. Since https://github.com/pre-commit/mirrors-prettier is archived, we won't expect anything beyond that alpha