### PR TITLE
chore: add back doc redirects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 # In code review, collapse generated files
-docs/*.md linguist-generated=true
+docs/*.md   linguist-generated=true
+docs/jq.md  linguist-generated=false
+docs/tar.md linguist-generated=false
+docs/yq.md  linguist-generated=false
+
 
 #################################
 # Configuration for 'git archive'

--- a/docs/jq.md
+++ b/docs/jq.md
@@ -1,0 +1,3 @@
+# jq rule
+
+This has been moved to https://github.com/bazel-contrib/jq.bzl

--- a/docs/tar.md
+++ b/docs/tar.md
@@ -1,0 +1,3 @@
+# tar rule
+
+This has been moved to https://github.com/bazel-contrib/tar.bzl

--- a/docs/yq.md
+++ b/docs/yq.md
@@ -1,0 +1,3 @@
+# yq rule
+
+This has been moved to https://github.com/bazel-contrib/yq.bzl


### PR DESCRIPTION
User report: the top result on Google is https://github.com/bazel-contrib/bazel-lib/blob/main/docs/tar.md which is now a 404, and I couldn't see any obvious signposts.