### PR TITLE
feat: apply rules_shell fixes to WORKSPACE

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -76,6 +76,13 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies",
 
 aspect_bazel_lib_dependencies()
 
+# Required rules_shell dependencies
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
 # Register bazel-lib toolchains
 
 aspect_bazel_lib_register_toolchains()

--- a/e2e/smoke/WORKSPACE
+++ b/e2e/smoke/WORKSPACE
@@ -7,6 +7,13 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies",
 
 aspect_bazel_lib_dependencies()
 
+# Required rules_shell dependencies
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
 aspect_bazel_lib_register_toolchains()
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -51,6 +51,12 @@ def aspect_bazel_lib_dependencies():
         strip_prefix = "yq.bzl-0.1.1",
         url = "https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz",
     )
+    http_archive(
+        name = "rules_shell",
+        sha256 = "bc61ef94facc78e20a645726f64756e5e285a045037c7a61f65af2941f4c25e1",
+        strip_prefix = "rules_shell-0.4.1",
+        url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz",
+    )
 
 DEFAULT_JQ_REPOSITORY = "jq"
 DEFAULT_JQ_VERSION = _DEFAULT_JQ_VERSION


### PR DESCRIPTION
772d605 fixed the bzlmod files but not the workspace files. I should note that there doesn't seem to be a way to test this locally, just in CI, which makes it pretty hard to figure out what's broken...