### PR TITLE
chore: allow release workflow to be called from tag.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_call:
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
 permissions:
   id-token: write
   attestations: write


### PR DESCRIPTION
I missed this in #1104 