### PR TITLE
feat: Propose experimental_remote_cache_eviction_retries=5 for bazel 7

### DIFF
--- a/.aspect/bazelrc/bazel7.bazelrc
+++ b/.aspect/bazelrc/bazel7.bazelrc
@@ -21,3 +21,8 @@ common --reuse_sandbox_directories
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 common --nolegacy_external_runfiles
+
+# The maximum number of attempts to retry if the build encountered a transient remote cache error that would otherwise fail the build.
+# Using the same value here than what is the default in Bazel 8 to help with https://github.com/bazelbuild/bazel/issues/22387
+# Docs: https://bazel.build/reference/command-line-reference#build-flag--experimental_remote_cache_eviction_retries
+common --experimental_remote_cache_eviction_retries=5


### PR DESCRIPTION
This is helpful to avoid https://github.com/bazelbuild/bazel/issues/22387 and set to 5 for bazel 8, so we should also do this for bazel 7.