### PR TITLE
Use default value of 5 for repository downloader

### DIFF
--- a/.aspect/bazelrc/bazel6.bazelrc
+++ b/.aspect/bazelrc/bazel6.bazelrc
@@ -54,3 +54,10 @@ query --experimental_allow_tags_propagation
 # author.
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
+
+# The maximum number of attempts to retry a download error.
+# Using the default value from Bazel 8.
+# Docs: https://bazel.build/reference/command-line-reference#common_options-flag--experimental_repository_downloader_retries
+build --experimental_repository_downloader_retries=5
+fetch --experimental_repository_downloader_retries=5
+query --experimental_repository_downloader_retries=5

--- a/.aspect/bazelrc/bazel7.bazelrc
+++ b/.aspect/bazelrc/bazel7.bazelrc
@@ -26,3 +26,8 @@ common --nolegacy_external_runfiles
 # Using the same value here than what is the default in Bazel 8 to help with https://github.com/bazelbuild/bazel/issues/22387
 # Docs: https://bazel.build/reference/command-line-reference#build-flag--experimental_remote_cache_eviction_retries
 common --experimental_remote_cache_eviction_retries=5
+
+# The maximum number of attempts to retry a download error.
+# Using the default value from Bazel 8.
+# Docs: https://bazel.build/reference/command-line-reference#common_options-flag--experimental_repository_downloader_retries
+common --experimental_repository_downloader_retries=5


### PR DESCRIPTION
Similar to https://github.com/bazel-contrib/bazel-lib/pull/1106 using the retry default from bazel 8 should help with stability issues