### PR TITLE
fix: remove references to incompatible_use_toolchain_transition

### DIFF
--- a/lib/private/copy_directory_toolchain.bzl
+++ b/lib/private/copy_directory_toolchain.bzl
@@ -116,7 +116,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:copy_directory_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/copy_to_directory_toolchain.bzl
+++ b/lib/private/copy_to_directory_toolchain.bzl
@@ -116,7 +116,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:copy_to_directory_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -153,7 +153,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/expand_template_toolchain.bzl
+++ b/lib/private/expand_template_toolchain.bzl
@@ -116,7 +116,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:expand_template_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/jq_toolchain.bzl
+++ b/lib/private/jq_toolchain.bzl
@@ -121,7 +121,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:jq_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/source_toolchains_repo.bzl
+++ b/lib/private/source_toolchains_repo.bzl
@@ -34,7 +34,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["{toolchain_type}"],
-    incompatible_use_toolchain_transition = True,
 )
 """
 

--- a/lib/private/tar_toolchain.bzl
+++ b/lib/private/tar_toolchain.bzl
@@ -172,7 +172,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:tar_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -386,7 +386,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:yq_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/lib/private/zstd_toolchain.bzl
+++ b/lib/private/zstd_toolchain.bzl
@@ -141,7 +141,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_bazel_lib//lib:zstd_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)


### PR DESCRIPTION
This was removed by Bazel in bazelbuild/bazel@f53608ac3dbfd02cecb4bb78a138badb0d84e311.
