### PR TITLE
fix: --build_runfile_links only for coverage

### DIFF
--- a/.aspect/bazelrc/performance.bazelrc
+++ b/.aspect/bazelrc/performance.bazelrc
@@ -16,4 +16,4 @@ common --nobuild_runfile_links
 
 # Needed prior to Bazel 8; see
 # https://github.com/bazelbuild/bazel/issues/20577
-common --build_runfile_links
+coverage --build_runfile_links


### PR DESCRIPTION
Reported in https://github.com/bazel-contrib/bazel-lib/pull/1099#issuecomment-2979976616, we now set both options for common. `--build_runfile_links` should be only set for coverage though.