### PR TITLE
feat(bazelrc): Add bazelrc preset for protoc

### DIFF
--- a/.aspect/bazelrc/protoc.bazelrc
+++ b/.aspect/bazelrc/protoc.bazelrc
@@ -1,0 +1,10 @@
+# Flags for using https://github.com/aspect-build/toolchains_protoc
+
+# Introduced in Bazel 7.
+common --incompatible_enable_proto_toolchain_resolution
+
+# Ensure that we don't accidentally build protobuf or gRPC
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT


### PR DESCRIPTION
https://github.com/aspect-build/toolchains_protoc requires some bazel flags to be set, so why not make it a preset to be more user friendly.