### PR TITLE
fix: Wrap reference to @platforms in Label()

### DIFF
--- a/lib/private/docs.bzl
+++ b/lib/private/docs.bzl
@@ -20,7 +20,7 @@ def stardoc_with_diff_test(
     target_compatible_with = kwargs.pop("target_compatible_with", select({
         # stardoc produces different line endings on Windows
         # which makes the diff_test fail
-        "@platforms//os:windows": ["@platforms//:incompatible"],
+        Label("@platforms//os:windows"): [Label("@platforms//:incompatible")],
         "//conditions:default": [],
     }))
 


### PR DESCRIPTION
This macro only works when it is invoked from within a repository that has an explicit dependency on @platforms. This repo needs to be pulled in manually nowadays, meaning that it is no longer guaranteed to be available. By wrapping this in Label(), we force resolution using the MODULE.bazel declared in aspect-bazel-lib itself.