### PR TITLE
chore: add windows_arm64 support to yq

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -206,7 +206,7 @@ Registers yq toolchain and repositories
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="register_yq_toolchains-name"></a>name |  override the prefix for the generated toolchain repositories   |  `"yq"` |
-| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  `"4.45.1"` |
+| <a id="register_yq_toolchains-version"></a>version |  the version of yq to execute (see https://github.com/mikefarah/yq/releases)   |  `"4.45.2"` |
 | <a id="register_yq_toolchains-register"></a>register |  whether to call through to native.register_toolchains. Should be True for WORKSPACE users, but false when used under bzlmod extension   |  `True` |
 
 

--- a/lib/private/yq_toolchain.bzl
+++ b/lib/private/yq_toolchain.bzl
@@ -52,11 +52,17 @@ YQ_PLATFORMS = {
             "@platforms//cpu:x86_64",
         ],
     ),
+    "windows_arm64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
 }
 
 # Note: this is not the latest release, because it has significant breaking changes.
 # See https://github.com/bazel-contrib/bazel-lib/pull/421
-DEFAULT_YQ_VERSION = "4.45.1"
+DEFAULT_YQ_VERSION = "4.45.2"
 
 # https://github.com/mikefarah/yq/releases
 #
@@ -67,6 +73,17 @@ DEFAULT_YQ_VERSION = "4.45.1"
 # Alternatively, you can compute them manually by running
 # `shasum -b -a 384 [downloaded file] | awk '{ print $1 }' | xxd -r -p | base64`
 YQ_VERSIONS = {
+    "4.45.2": {
+        "darwin_amd64": "sha384-TBsrUTy6n6qA2hiSlpnEN6iEDDz4Tiy++AxLOpeXU1aUaI6uIuEBx8hgPYWWuD8V",
+        "darwin_arm64": "sha384-bnZ5TqsG5pcWB6gC87QKrBrjcKYmdOcSD7TpFVeCU6Nj7z5egeZzm4BH1FHbqo0e",
+        "linux_amd64": "sha384-jEOdMXHPvRiaFXWRnSA5Mw41VCKkNPv42i35i9BiVxrAnfyl/3/Li/iyQyj16QIr",
+        "linux_arm64": "sha384-4bEWn6fDQhIomb6Smzm8yw26RvqsjHh3PH/SogwWoLC9uJRoyQagY2PJZaYWxUDY",
+        "linux_s390x": "sha384-9uU3CXqjUG/SuPiHPKIUqbOVyqx7JiVOtRzeFta9IBFkJyUB0pBBOYkoDppvrmzz",
+        "linux_riscv64": "sha384-FWM1djpKjWctmhaInat/z/CcwQuiqLTeQcb0MMU5+sNiwMTuWyjvNlbwA4rRG3ZQ",
+        "linux_ppc64le": "sha384-bB03rZ0ptRt2EuFnA9SvscPMe3gVJecBvxhzPbYe7wsfoHvzzYqWffCchZVxRg+9",
+        "windows_amd64": "sha384-vG8R2+s/sD8DbeCM9H0xCy5JgtAOII7SLRx2g+ALtQZWW/q3XjXlzN2CKW/zU+EH",
+        "windows_arm64": "sha384-XHgi894S4cQ2qgJx47cPu5vtb2MOXA2YZ7QgExODwNoIPhji5wXK2MrgMB+RI7gZ",
+    },
     "4.45.1": {
         "darwin_amd64": "sha384-ZoEgzfCLmDk7eoKdJSoq/nny1iX3Cq9mMJ3gnPZ2ejhKMxSgHUQIa7MREToxYl6Z",
         "darwin_arm64": "sha384-nHYFqoarTzGba/XtpN8N3U0X9hMTg64Vn7XZ8yiF2cbJFdY3VWFVw80vsg/JXaOg",

--- a/tools/yq_mirror_release.sh
+++ b/tools/yq_mirror_release.sh
@@ -21,7 +21,7 @@ chmod u+x extract-checksum.sh
 
 # Extract the checksums and output a starlark map entry
 echo "\"$version\": {"
-platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,riscv64,ppc64le} windows_amd64)
+platforms=(darwin_{amd64,arm64} linux_{amd64,arm64,s390x,riscv64,ppc64le} windows_{amd64,arm64})
 for release in ${platforms[@]}; do
   artifact=$release
   if [[ $release == windows* ]]; then


### PR DESCRIPTION
Partially addresses https://github.com/bazel-contrib/bazel-lib/issues/1076

Upstream has introduced support for windows_arm64 recently, so it can be referenced now.