### PR TITLE
feat: fix zstd_toolchain and enable root tests on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,11 @@ common --incompatible_auto_exec_groups
 # Symlinks are pretty much required on windows so enable by default
 startup --windows_enable_symlinks
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # This option fixes 20 tests on Windows but I am reluctant to enable it as it would be
 # better for this library to be tested with runfiles off (it is a performance drain on windows).
 # common:windows --enable_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,7 +36,6 @@ startup --windows_enable_symlinks
 # Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
 # suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
 common --repo_env=JAVA_HOME=../bazel_tools/jdk
-common --action_env=JAVA_HOME=../bazel_tools/jdk
 
 # This option fixes 20 tests on Windows but I am reluctant to enable it as it would be
 # better for this library to be tested with runfiles off (it is a performance drain on windows).

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,7 @@ import %workspace%/.aspect/bazelrc/javascript.bazelrc
 import %workspace%/.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+common --enable_platform_specific_config
 
 # For testing our --stamp behavior.
 # Normally users would use a --workspace_status_command with a script that calls `git describe`.
@@ -28,6 +29,13 @@ common --check_direct_dependencies=off
 
 # Make sure we don't regress this.
 common --incompatible_auto_exec_groups
+
+# Symlinks are pretty much required on windows so enable by default
+startup --windows_enable_symlinks
+
+# This option fixes 20 tests on Windows but I am reluctant to enable it as it would be
+# better for this library to be tested with runfiles off (it is a performance drain on windows).
+# common:windows --enable_runfiles
 
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This

--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -11,7 +11,7 @@ index e63fa5b..9d78a88 100644
  )
  bazel_dep(
      name = "rules_go",
-     version = "0.51.0",
+     version = "0.55.0",
      repo_name = "io_bazel_rules_go",
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,

--- a/.bcr/patches/go_dev_dep.patch
+++ b/.bcr/patches/go_dev_dep.patch
@@ -2,7 +2,7 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 index e63fa5b..9d78a88 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -50,19 +50,19 @@ use_repo(host, "aspect_bazel_lib_host")
+@@ -52,26 +52,26 @@ use_repo(host, "aspect_bazel_lib_host")
  bazel_dep(
      name = "gazelle",
      version = "0.40.0",
@@ -16,6 +16,14 @@ index e63fa5b..9d78a88 100644
 -    # In released versions: dev_dependency = True
 +    dev_dependency = True,
  )
+
+ go_sdk = use_extension(
+     "@io_bazel_rules_go//go:extensions.bzl",
+     "go_sdk",
+-    # In released versions: dev_dependency = True
++    dev_dependency = True,
+ )
+ go_sdk.from_file(go_mod = "//:go.mod")
 
  go_deps = use_extension(
      "@gazelle//:extensions.bzl",

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -4,3 +4,6 @@ common --repository_cache=~/.cache/bazel-repository-cache
 
 # Debug where options came from
 common --announce_rc
+
+# Keep bazel stdout readable in logs
+common --noshow_progress

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,11 +89,9 @@ jobs:
           - bazel-version:
               major: 6
             bzlmod: 1
-          # TODO: green up root Workspace on MacOS & Windows
+          # TODO: green up root Workspace on MacOS
           - folder: .
             os: macos
-          - folder: .
-            os: windows
         include:
           - folder: docs
             bzlmod: 1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,7 +112,8 @@ assert_contains(
     name = "bazel_version_test",
     actual = ".bazelversion",
     expected = str(host.bazel_version),
-    target_compatible_with = [] if host.bazel_version.startswith("7") else ["@platforms//:incompatible"],
+    # TODO: Enable this for windows
+    target_compatible_with = [] if host.bazel_version.startswith("7") and not host.is_windows else ["@platforms//:incompatible"],
 )
 
 bzl_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
 bazel_dep(name = "bazel_features", version = "1.9.0")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "stardoc", version = "0.7.1")
 bazel_dep(name = "rules_shell", version = "0.4.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "stardoc", version = "0.6.2")
+bazel_dep(name = "stardoc", version = "0.7.1")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 
 # TODO(3.0): remove this back-compat
@@ -56,7 +56,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.51.0",
+    version = "0.55.0",
     repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,11 @@ bazel_dep(
     repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+
+# Download an SDK for the host OS & architecture as well as common remote execution
+# platforms, using the version given from the `go.mod` file.
+go_sdk.from_file(go_mod = "//:go.mod")
 
 go_deps = use_extension(
     "@gazelle//:extensions.bzl",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,10 +60,12 @@ bazel_dep(
     repo_name = "io_bazel_rules_go",
     # In released versions: dev_dependency = True
 )
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
-# Download an SDK for the host OS & architecture as well as common remote execution
-# platforms, using the version given from the `go.mod` file.
+go_sdk = use_extension(
+    "@io_bazel_rules_go//go:extensions.bzl",
+    "go_sdk",
+    # In released versions: dev_dependency = True
+)
 go_sdk.from_file(go_mod = "//:go.mod")
 
 go_deps = use_extension(

--- a/e2e/api_entries/MODULE.bazel
+++ b/e2e/api_entries/MODULE.bazel
@@ -4,4 +4,4 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)

--- a/e2e/copy_action/.bazelrc
+++ b/e2e/copy_action/.bazelrc
@@ -8,6 +8,11 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/copy_action/MODULE.bazel
+++ b/e2e/copy_action/MODULE.bazel
@@ -4,4 +4,4 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)

--- a/e2e/copy_to_directory/.bazelrc
+++ b/e2e/copy_to_directory/.bazelrc
@@ -8,6 +8,11 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/copy_to_directory/MODULE.bazel
+++ b/e2e/copy_to_directory/MODULE.bazel
@@ -4,4 +4,4 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)

--- a/e2e/coreutils/.bazelrc
+++ b/e2e/coreutils/.bazelrc
@@ -8,6 +8,11 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/external_copy_to_directory/.bazelrc
+++ b/e2e/external_copy_to_directory/.bazelrc
@@ -8,6 +8,11 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/external_copy_to_directory/MODULE.bazel
+++ b/e2e/external_copy_to_directory/MODULE.bazel
@@ -4,4 +4,4 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -11,6 +11,10 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 # For testing expand_template
 common --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -4,5 +4,5 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.53.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.55.0", dev_dependency = True, repo_name = "io_bazel_rules_go")

--- a/e2e/write_source_files/.bazelrc
+++ b/e2e/write_source_files/.bazelrc
@@ -8,6 +8,11 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module github.com/bazel-contrib/bazel-lib
 
-go 1.22
-
-toolchain go1.24.0
+<!-- 
+upgrade to go 1.23 may require fixing copy.go as there are some 
+changes in symlink handling in go/windows.
+These are caught by e2e\smoke
+https://tip.golang.org/doc/go1.23#ospkgos
+-->
+go 1.22.7
 
 require (
-	github.com/bazelbuild/rules_go v0.53.0
+	github.com/bazelbuild/rules_go v0.55.0
 	github.com/bmatcuk/doublestar/v4 v4.7.1
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/sys v0.30.0

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,5 @@
 module github.com/bazel-contrib/bazel-lib
 
-<!-- 
-upgrade to go 1.23 may require fixing copy.go as there are some 
-changes in symlink handling in go/windows.
-These are caught by e2e\smoke
-https://tip.golang.org/doc/go1.23#ospkgos
--->
 go 1.22.7
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
-github.com/bazelbuild/rules_go v0.52.0 h1:+ozpngVAW67pCAwfhepaXSSrG3yHcj8K9hNAxSYBno4=
-github.com/bazelbuild/rules_go v0.52.0/go.mod h1:M+YrupNArA7OiTlv++rFUgQ6Sm+ZXbQ5HPUj0cGa0us=
-github.com/bazelbuild/rules_go v0.53.0 h1:u160DT+RRb+Xb2aSO4piN8xhs4aZvWz2UDXCq48F4ao=
-github.com/bazelbuild/rules_go v0.53.0/go.mod h1:xB1jfsYHWlnZyPPxzlOSst4q2ZAwS251Mp9Iw6TPuBc=
+github.com/bazelbuild/rules_go v0.55.0 h1:S8X/b/Oygw/Dtv7NuyW7ht0QwdynMEdXQqYigX5A1KY=
+github.com/bazelbuild/rules_go v0.55.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
 github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 h1:kx6Ds3MlpiUHKj7syVnbp57++8WpuKPcR5yjLBjvLEA=
 golang.org/x/exp v0.0.0-20240823005443-9b4947da3948/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/lib/private/coreutils_toolchain.bzl
+++ b/lib/private/coreutils_toolchain.bzl
@@ -32,6 +32,12 @@ COREUTILS_PLATFORMS = {
             "@platforms//cpu:x86_64",
         ],
     ),
+    "windows_arm64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
 }
 
 # https://github.com/uutils/coreutils/releases

--- a/lib/private/zstd_toolchain.bzl
+++ b/lib/private/zstd_toolchain.bzl
@@ -25,6 +25,12 @@ ZSTD_PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
+    "windows_amd64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
+        ],
+    ),
 }
 
 ZSTD_PREBUILT = {
@@ -41,6 +47,14 @@ ZSTD_PREBUILT = {
         "0f0bd1193509a598629d7fa745c4b0b6d5fa6719e0c94c01ef0f20e466d801a7",
     ),
     "linux_arm64": (
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
+        "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
+    ),
+    "windows_amd64": (
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
+        "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
+    ),
+    "windows_arm64": (
         "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
         "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
     ),

--- a/lib/private/zstd_toolchain.bzl
+++ b/lib/private/zstd_toolchain.bzl
@@ -35,28 +35,28 @@ ZSTD_PLATFORMS = {
 
 ZSTD_PREBUILT = {
     "darwin_amd64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_darwin_amd64",
-        "e4d517212005cf26f8b8d657455d1380318b071cb52a3ffd9dfbdf4c2ba71a13",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_darwin_amd64",
+        "E4D517212005CF26F8B8D657455D1380318B071CB52A3FFD9DFBDF4C2BA71A13",
     ),
     "darwin_arm64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_darwin_arm64",
-        "6e210eeae08fb6ba38c3ac2d1857075c28113aef68296f7e396f1180f7e894b9",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_darwin_arm64",
+        "6E210EEAE08FB6BA38C3AC2D1857075C28113AEF68296F7E396F1180F7E894B9",
     ),
     "linux_amd64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_amd64",
-        "0f0bd1193509a598629d7fa745c4b0b6d5fa6719e0c94c01ef0f20e466d801a7",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_linux_amd64",
+        "0F0BD1193509A598629D7FA745C4B0B6D5FA6719E0C94C01EF0F20E466D801A7",
     ),
     "linux_arm64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
-        "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_linux_arm64",
+        "82AACF8F1C67FF3C94E04AFB0721A848BBBA70FBF8249EE4BC4C9085AFB84548",
     ),
     "windows_amd64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
-        "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_windows_x86_64.exe",
+        "A944FDE13D01892C7CF0970FE4271F9561373F5E0A46ECEA756B6AE9A31E056C",
     ),
     "windows_arm64": (
-        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6/zstd_linux_arm64",
-        "82aacf8f1c67ff3c94e04afb0721a848bbba70fbf8249ee4bc4c9085afb84548",
+        "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr1/zstd_windows_arm64.exe",
+        "8CA462473BCCD13C9D9A952F09E5F628153785323949D539E8858B2ABB85E246",
     ),
 }
 

--- a/lib/tests/BUILD.bazel
+++ b/lib/tests/BUILD.bazel
@@ -70,6 +70,10 @@ assert_contains(
     name = "expand_template_contains",
     actual = "expand_template_test.sh",
     expected = "stuff",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 bzl_library(

--- a/lib/tests/assert_contains/BUILD.bazel
+++ b/lib/tests/assert_contains/BUILD.bazel
@@ -6,16 +6,28 @@ assert_contains(
     name = "regexy-args-1",
     actual = ":case1.txt",
     expected = "--arg1='/{{[{]?(.*?)[}]?}}/'",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 assert_contains(
     name = "regexy-args-2",
     actual = ":case1.txt",
     expected = "--arg2='/{%(.*?)%}/'",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 assert_contains(
     name = "backtick",
     actual = ":case1.txt",
     expected = "`ff`",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/lib/tests/bats/BUILD.bazel
+++ b/lib/tests/bats/BUILD.bazel
@@ -40,6 +40,10 @@ bats_test(
     env = {
         "DATA_PATH": "$(location :data.bin)",
     },
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 bats_test(

--- a/lib/tests/bats/BUILD.bazel
+++ b/lib/tests/bats/BUILD.bazel
@@ -26,6 +26,11 @@ bats_test(
         "basic.bats",
     ],
     args = ["--timing"],
+    # flaky on windows; timeouts
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    })
 )
 
 bats_test(

--- a/lib/tests/copy_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_directory_bin_action/BUILD.bazel
@@ -1,25 +1,16 @@
 load("//lib:diff_test.bzl", "diff_test")
 load(":pkg.bzl", "pkg")
 
-not_windows = select({
-    # 2023/10/10 18:59:00 lstat lib\tests\copy_directory_bin_action\d\d\s1 failed:
-    # CreateFile .\1: The system cannot find the file specified.
-    "@platforms//os:windows": ["@platforms//:incompatible"],
-    "//conditions:default": [],
-})
-
 pkg(
     name = "pkg",
     src = "d",
     out = "d2",
-    target_compatible_with = not_windows,
 )
 
 pkg(
     name = "pkg2",
     src = "pkg",
     out = "d3",
-    target_compatible_with = not_windows,
 )
 
 diff_test(

--- a/lib/tests/copy_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_directory_bin_action/BUILD.bazel
@@ -17,16 +17,31 @@ diff_test(
     name = "copy_test",
     file1 = ":d",
     file2 = ":pkg",
+    # TODO: re-enable this test on windows
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 diff_test(
     name = "hardlink_test",
     file1 = ":d",
     file2 = ":pkg2",
+    # TODO: re-enable this test on windows
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 diff_test(
     name = "sanity_test",
     file1 = ":pkg",
     file2 = ":pkg2",
+    # TODO: re-enable this test on windows
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )

--- a/lib/tests/copy_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_directory_bin_action/BUILD.bazel
@@ -1,16 +1,25 @@
 load("//lib:diff_test.bzl", "diff_test")
 load(":pkg.bzl", "pkg")
 
+NOT_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 pkg(
     name = "pkg",
     src = "d",
     out = "d2",
+    # TODO: re-enable this test on windows
+    target_compatible_with = NOT_WINDOWS,
 )
 
 pkg(
     name = "pkg2",
     src = "pkg",
     out = "d3",
+    # TODO: re-enable this test on windows
+    target_compatible_with = NOT_WINDOWS,
 )
 
 diff_test(
@@ -18,10 +27,7 @@ diff_test(
     file1 = ":d",
     file2 = ":pkg",
     # TODO: re-enable this test on windows
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = NOT_WINDOWS,
 )
 
 diff_test(
@@ -29,10 +35,7 @@ diff_test(
     file1 = ":d",
     file2 = ":pkg2",
     # TODO: re-enable this test on windows
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = NOT_WINDOWS,
 )
 
 diff_test(
@@ -40,8 +43,5 @@ diff_test(
     file1 = ":pkg",
     file2 = ":pkg2",
     # TODO: re-enable this test on windows
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = NOT_WINDOWS,
 )

--- a/lib/tests/copy_to_directory/BUILD.bazel
+++ b/lib/tests/copy_to_directory/BUILD.bazel
@@ -151,6 +151,10 @@ copy_to_directory(
     name = "case_6",
     srcs = case_srcs,
     include_external_repositories = ["external_test_repo?"],
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 # TODO: This test is a false positive. sh_test always includes default

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -52,12 +52,12 @@ pkg(
     out = "pkg",
     # RBE not happy with the symlinks in this test case
     tags = ["no-remote"],
+    # TODO: re-enable this test on windows
+    target_compatible_with = NOT_WINDOWS,
     use_declare_symlink = select({
         "//lib/tests:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
-    # TODO: re-enable this test on windows
-    target_compatible_with = NOT_WINDOWS,
 )
 
 diff_test(

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -51,6 +51,11 @@ pkg(
         "//lib/tests:allow_unresolved_symlinks": True,
         "//conditions:default": False,
     }),
+    # TODO: re-enable this test on windows
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 diff_test(

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -5,6 +5,11 @@ load("//lib:diff_test.bzl", "diff_test")
 load(":lib.bzl", "lib")
 load(":pkg.bzl", "pkg")
 
+NOT_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 copy_to_bin(
     name = "copy_1",
     srcs = ["1"],
@@ -52,10 +57,7 @@ pkg(
         "//conditions:default": False,
     }),
     # TODO: re-enable this test on windows
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = NOT_WINDOWS,
 )
 
 diff_test(
@@ -65,10 +67,7 @@ diff_test(
     # RBE not happy with the symlinks in this test case
     tags = ["no-remote"],
     # TODO: re-enable this test on windows
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = NOT_WINDOWS,
 )
 
 bzl_library(

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -47,12 +47,6 @@ pkg(
     out = "pkg",
     # RBE not happy with the symlinks in this test case
     tags = ["no-remote"],
-    target_compatible_with = select({
-        # D:/a/bazel-lib/bazel-lib/lib/tests/copy_to_directory_bin_action/BUILD.bazel:36:4:
-        # declared output 'lib/tests/copy_to_directory_bin_action/pkg_symlink_0' is not a symlink
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     use_declare_symlink = select({
         "//lib/tests:allow_unresolved_symlinks": True,
         "//conditions:default": False,

--- a/lib/tests/copy_to_directory_bin_action/BUILD.bazel
+++ b/lib/tests/copy_to_directory_bin_action/BUILD.bazel
@@ -59,6 +59,11 @@ diff_test(
     file2 = ":expected_pkg",
     # RBE not happy with the symlinks in this test case
     tags = ["no-remote"],
+    # TODO: re-enable this test on windows
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 bzl_library(

--- a/lib/tests/coreutils/BUILD.bazel
+++ b/lib/tests/coreutils/BUILD.bazel
@@ -62,4 +62,8 @@ assert_contains(
     name = "test_wc",
     actual = "wc.txt",
     expected = """0 1 4 lib/tests/coreutils/test.bin""",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/lib/tests/coreutils/BUILD.bazel
+++ b/lib/tests/coreutils/BUILD.bazel
@@ -14,11 +14,13 @@ diff_test(
     file2 = ":ls",
 )
 
+# Windows platform writes ' *' between hash and filename; Linux writes '  '.
+# use sed to transform windows output into linux style before assertion.
 genrule(
     name = "sha256sum",
     srcs = ["test.bin"],
     outs = ["sha256sum.txt"],
-    cmd = "$(COREUTILS_BIN) sha256sum $(location :test.bin) > $@",
+    cmd = "$(COREUTILS_BIN) sha256sum $(location :test.bin) | sed 's/ \\*/  /' > $@",
     toolchains = ["@coreutils_toolchains//:resolved_toolchain"],
 )
 
@@ -27,16 +29,18 @@ assert_contains(
     actual = "sha256sum.txt",
     expected = """9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08  lib/tests/coreutils/test.bin""",
     target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
 
+# Windows platform writes ' *' between hash and filename; Linux writes '  '.
+# use sed to transform windows output into linux style before assertion.
 genrule(
     name = "sha512sum",
     srcs = ["test.bin"],
     outs = ["sha512sum.txt"],
-    cmd = "$(COREUTILS_BIN) sha512sum $(location :test.bin) > $@",
+    cmd = "$(COREUTILS_BIN) sha512sum $(location :test.bin) | sed 's/ \\*/  /' > $@",
     toolchains = ["@coreutils_toolchains//:resolved_toolchain"],
 )
 
@@ -45,8 +49,8 @@ assert_contains(
     actual = "sha512sum.txt",
     expected = """ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff  lib/tests/coreutils/test.bin""",
     target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
     }),
 )
 

--- a/lib/tests/expand_template/BUILD.bazel
+++ b/lib/tests/expand_template/BUILD.bazel
@@ -57,6 +57,10 @@ assert_contains(
     name = "default_info_test",
     actual = ":a_tmpl_stamp",
     expected = "WORKSPACE:",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 # No `out` specified, because we don't care what the name of the generated file is.
@@ -73,6 +77,10 @@ assert_contains(
     name = "inline_template_test",
     actual = ":inline_template",
     expected = "line3",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 # When `out` is not specified, the output file is the same name as the template
@@ -89,4 +97,8 @@ assert_contains(
     name = "index_html_out_test",
     actual = ":index_html_out",
     expected = "index.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/lib/tests/run_binary/BUILD.bazel
+++ b/lib/tests/run_binary/BUILD.bazel
@@ -79,4 +79,8 @@ assert_contains(
     name = "dir_a_rootpath_test",
     actual = ":dir_a_rootpath",
     expected = "lib/tests/run_binary/dir_a_out",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -152,6 +152,10 @@ sh_test(
         "x86-64",
     ],
     data = [":transitioned_go_binary_x86_64"],
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 sh_test(
@@ -163,6 +167,10 @@ sh_test(
         "aarch64",
     ],
     data = [":transitioned_go_binary_arm64"],
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 sh_test(
@@ -174,6 +182,10 @@ sh_test(
         "x86-64",
     ],
     data = [":transitioned_go_test_x86_64"],
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 sh_test(

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -135,7 +135,7 @@ platform_transition_test(
 platform_transition_test(
     name = "transitioned_go_test_arm64",
     binary = ":test_transition_test",
-    # only run this test on an x86_64 host
+    # only run this test on an arm64 host
     target_compatible_with = [] if sorted(HOST_CONSTRAINTS) == [
         "@platforms//cpu:aarch64",
         "@platforms//os:linux",

--- a/lib/tests/write_source_files/BUILD.bazel
+++ b/lib/tests/write_source_files/BUILD.bazel
@@ -118,12 +118,20 @@ write_source_file_test(
     name = "a_test",
     in_file = ":a-desired",
     out_file = "a.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 write_source_file_test(
     name = "b_test",
     in_file = ":b-desired",
     out_file = "b.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 write_source_file(
@@ -144,12 +152,20 @@ write_source_file_test(
     name = "f_test",
     in_file = ":f-desired",
     out_file = "f.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 write_source_file_test(
     name = "g_test",
     in_file = ":g-desired",
     out_file = "g.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 write_source_file(
@@ -172,6 +188,10 @@ write_source_files(
         "f2.js": ":f-desired",
         "g2.js": ":g-desired",
     },
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 genrule(
@@ -233,6 +253,10 @@ write_source_file_test(
     check_that_out_file_exists = False,
     in_file = ":a-desired",
     out_file = "//lib/tests/write_source_files/subpkg:a.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 # Test that we can write to a parent package
@@ -241,4 +265,8 @@ write_source_file_test(
     check_that_out_file_exists = False,
     in_file = ":a-desired",
     out_file = "//lib/tests:a.js",
+    target_compatible_with = select({
+        "@aspect_bazel_lib//lib:enable_runfiles": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )

--- a/lib/tests/write_source_files/write_source_file_test.bzl
+++ b/lib/tests/write_source_files/write_source_file_test.bzl
@@ -172,7 +172,7 @@ _write_source_file_test = rule(
     test = True,
 )
 
-def write_source_file_test(name, in_file, out_file, check_that_out_file_exists = True, size = "small"):
+def write_source_file_test(name, in_file, out_file, check_that_out_file_exists = True, size = "small", **kwargs):
     """Stamp a write_source_files executable and a test to run against it"""
 
     _write_source_file(
@@ -191,4 +191,5 @@ def write_source_file_test(name, in_file, out_file, check_that_out_file_exists =
         in_file = in_file,
         out_file = out_file,
         size = size,
+        **kwargs,
     )

--- a/lib/tests/write_source_files/write_source_file_test.bzl
+++ b/lib/tests/write_source_files/write_source_file_test.bzl
@@ -191,5 +191,5 @@ def write_source_file_test(name, in_file, out_file, check_that_out_file_exists =
         in_file = in_file,
         out_file = out_file,
         size = size,
-        **kwargs,
+        **kwargs
     )

--- a/lib/tests/zstd/BUILD.bazel
+++ b/lib/tests/zstd/BUILD.bazel
@@ -7,7 +7,10 @@ genrule(
         "srcfile",
     ],
     outs = ["1.tar.gz"],
-    cmd = "$(BSDTAR_BIN) --create --gzip --dereference --file $@ -s '#$(BINDIR)##' $(execpath srcfile)",
+    cmd = select({
+        "@platforms//os:windows": "$(BSDTAR_BIN) -c -z --dereference --file $@ $(execpath srcfile)",
+        "//conditions:default": "$(BSDTAR_BIN) --create --gzip --dereference --file $@ -s '#$(BINDIR)##' $(execpath srcfile)",
+    }),
     toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
 )
 
@@ -18,6 +21,11 @@ genrule(
     ],
     outs = ["1.tar"],
     cmd = "$(ZSTD_BIN) -f --decompress $(execpath :tar) --stdout > $@",
+    target_compatible_with = select({
+        # zstd not supported on windows
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     toolchains = ["@zstd_toolchains//:resolved_toolchain"],
 )
 

--- a/lib/tests/zstd/BUILD.bazel
+++ b/lib/tests/zstd/BUILD.bazel
@@ -21,11 +21,6 @@ genrule(
     ],
     outs = ["1.tar"],
     cmd = "$(ZSTD_BIN) -f --decompress $(execpath :tar) --stdout > $@",
-    target_compatible_with = select({
-        # zstd not supported on windows
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     toolchains = ["@zstd_toolchains//:resolved_toolchain"],
 )
 

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -6,5 +6,6 @@ The checked in content is only here to allow load() statements in the sources to
 
 RELEASED_BINARY_INTEGRITY = {
     "copy_directory-darwin_amd64": "sha256-EH6Qpf/IzIaGncigN+cMc2xCb0C3XuV8I4cUBtaZ7GE=",
+    "copy_directory-windows_amd64.exe": "sha256-EH6Qpf/IzIaGncigN+cMc2xCb0C3XuV8I4cUBtaZ7GE=",
     # ...etc
 }

--- a/tools/integrity.bzl
+++ b/tools/integrity.bzl
@@ -6,6 +6,5 @@ The checked in content is only here to allow load() statements in the sources to
 
 RELEASED_BINARY_INTEGRITY = {
     "copy_directory-darwin_amd64": "sha256-EH6Qpf/IzIaGncigN+cMc2xCb0C3XuV8I4cUBtaZ7GE=",
-    "copy_directory-windows_amd64.exe": "sha256-EH6Qpf/IzIaGncigN+cMc2xCb0C3XuV8I4cUBtaZ7GE=",
     # ...etc
 }


### PR DESCRIPTION
* Enables zstd_toolchain for windows
* Fixes some tests
* 20 tests marked as incompatible with the Windows default of --noenable_runfiles
* Enables windows CI for root workspace; all green or skipped
* Bump rules_go 0.55 for fix https://github.com/bazel-contrib/rules_go/issues/4139 impacting windows/bazel7 tests
* Bump stardoc to 0.7.1 for fix https://github.com/bazelbuild/stardoc/pull/238 impacting windows/bazel7
* Bump skylib to 1.8.1 for fix https://github.com/bazelbuild/bazel-skylib/pull/574 resolving noisy warnings

Fixes:
* https://github.com/bazel-contrib/bazel-lib/issues/964

Opened new issues to track remaining issues I will be unable to tackle:
* https://github.com/bazel-contrib/bazel-lib/issues/1142
* https://github.com/bazel-contrib/bazel-lib/issues/1143
* https://github.com/bazel-contrib/bazel-lib/issues/1146

Final test results (root tests)
| Platform                 | Flags                     | Status                         |
|----------------------|--------------------|-------------------------|
| Windows / Bazel 7 |                              | 101 pass / 41 skipped | 
| Windows / Bazel 7 | --enable_runfiles  | 127 pass / 15 skipped | 
| Windows / Bazel 8 |                              | 101 pass / 41 skipped | 
| Windows / Bazel 8 | --enable_runfiles | 127 pass / 15 skipped | 
