### PR TITLE
chore(ci): run Linux testing on Buildkite

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -24,10 +24,5 @@ tasks:
       id: bazel-8
       env:
         USE_BAZEL_VERSION: 8.x
-  - test:
-      name: Test (Bazel 9.x)
-      id: bazel-9
-      env:
-        USE_BAZEL_VERSION: rolling
 notifications:
   github: {}

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,7 +1,10 @@
 # See https://docs.aspect.build/workflows/configuration
 workspaces:
   - .
-  - e2e/api_entries
+  - e2e/api_entries:
+      tasks:
+        - bazel-6:
+            without: true
   - e2e/copy_action
   - e2e/copy_to_directory
   - e2e/coreutils

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,0 +1,33 @@
+# See https://docs.aspect.build/workflows/configuration
+workspaces:
+  - .
+  - e2e/api_entries
+  - e2e/copy_action
+  - e2e/copy_to_directory
+  - e2e/coreutils
+  - e2e/external_copy_to_directory
+  - e2e/smoke
+  - e2e/write_source_files
+tasks:
+  - test:
+      name: "Test (Bazel 6.x)"
+      id: bazel-6
+      env:
+        USE_BAZEL_VERSION: 6.x
+  - test:
+      name: "Test (Bazel 7.x)"
+      id: bazel-7
+      env:
+        USE_BAZEL_VERSION: 7.x
+  - test:
+      name: "Test (Bazel 8.x)"
+      id: bazel-8
+      env:
+        USE_BAZEL_VERSION: 8.x
+  - test:
+      name: Test (Bazel 9.x)
+      id: bazel-9
+      env:
+        USE_BAZEL_VERSION: rolling
+notifications:
+  github: {}

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,6 +1,11 @@
 # See https://docs.aspect.build/workflows/configuration
 workspaces:
-  - .
+  - .:
+      tasks:
+        - bazel-6:
+            without: true
+        - bazel-7:
+            without: true
   - e2e/api_entries:
       tasks:
         - bazel-6:

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@ common:release -c opt
 common --check_direct_dependencies=off
 
 # Make sure we don't regress this.
-common --incompatible_auto_exec_groups
+# common --incompatible_auto_exec_groups
 
 # Symlinks are pretty much required on windows so enable by default
 startup --windows_enable_symlinks


### PR DESCRIPTION
Allows us to drastically simplify the GitHub Actions setup.

Note, we no longer explicitly pass any `--enable_bzlmod` or `--enable_workspace` flags, so we naturally get some WORKSPACE testing on Bazel 6, and bzlmod testing on Bazel 7 and Bazel 8. This doesn't assert on every combination and might miss some defects, but I think it's sufficient.