### PR TITLE
chore: be explicit that we require bazel 6.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "aspect_bazel_lib",
-    bazel_compatibility = [">=6.0.0"],
+    bazel_compatibility = [">=6.5.0"],
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
Attempting to use this repo with bazel 6.4.1 results in:

```
ERROR: https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel:89:13: name 'use_repo_rule' is not defined
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> aspect_bazel_lib@2.21.0 -> stardoc@0.7.1 -> rules_jvm_external@6.1: error executing MODULE.bazel file for rules_jvm_external@6.1
```

Document the minimum requirement of bazel 6.5.0. This is already configured in the CI matrix.
