### PR TITLE
chore: test on Bazel 9, drop Bazel 6

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -2,14 +2,9 @@
 workspaces:
   - .:
       tasks:
-        - bazel-6:
-            without: true
         - bazel-7:
             without: true
-  - e2e/api_entries:
-      tasks:
-        - bazel-6:
-            without: true
+  - e2e/api_entries
   - e2e/copy_action
   - e2e/copy_to_directory
   - e2e/coreutils
@@ -18,19 +13,19 @@ workspaces:
   - e2e/write_source_files
 tasks:
   - test:
-      name: "Test (Bazel 6.x)"
-      id: bazel-6
-      env:
-        USE_BAZEL_VERSION: 6.x
-  - test:
-      name: "Test (Bazel 7.x)"
+      name: Bazel 7
       id: bazel-7
       env:
         USE_BAZEL_VERSION: 7.x
   - test:
-      name: "Test (Bazel 8.x)"
+      name: Bazel 8
       id: bazel-8
       env:
         USE_BAZEL_VERSION: 8.x
+  - test:
+      name: Bazel 9
+      id: bazel-9
+      env:
+        USE_BAZEL_VERSION: rolling
 notifications:
   github: {}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,9 +3,9 @@ bcr_test_module:
   matrix:
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
     bazel:
-      - 6.x
       - 7.x
       - 8.x
+      - rolling
   tasks:
     run_tests:
       name: "Run test module"

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -53,16 +53,15 @@ tar --create --auto-compress \
 
 cat <<EOF
 
-## Using Bzlmod with Bazel 6:
+## Using Bzlmod
 
-1. Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
-2. Add to your \`MODULE.bazel\` file:
+Add to your \`MODULE.bazel\` file:
 
 \`\`\`starlark
 bazel_dep(name = "bazel_lib", version = "${TAG:1}")
 \`\`\`
 
-## Using WORKSPACE
+## Using WORKSPACE (deprecated)
 
 Paste this snippet into your \`WORKSPACE\` file:
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,2 +1,0 @@
-# Placeholder indicating the root of a Bazel Workspace, needed only so this repo can be tested against
-# Bazel 6 without --enable_bzlmod.

--- a/lib/tests/run_binary_expansions/expansions.sh
+++ b/lib/tests/run_binary_expansions/expansions.sh
@@ -7,6 +7,7 @@ rm -f "$outfile"
 for each in $@; do
   sanitized=${each/darwin/PLATFORM}
   sanitized=${sanitized/k8/PLATFORM}
+  sanitized=${sanitized/x86_64/PLATFORM}
   sanitized=${sanitized/x64_windows/PLATFORM}
   sanitized=${sanitized/_arm64/}
   echo "$sanitized" >>"$outfile"

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -22,7 +22,6 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
-        "@io_bazel_rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
     ],
 )
 
@@ -31,7 +30,6 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
-        "@io_bazel_rules_go//go/toolchain:cgo_off",  # https://github.com/bazelbuild/rules_go/pull/3390
     ],
 )
 
@@ -99,6 +97,7 @@ diff_test(
 go_binary(
     name = "test_transition_binary",
     embed = [":transitions_lib"],
+    pure = "on",
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )
@@ -106,6 +105,7 @@ go_binary(
 go_test(
     name = "test_transition_test",
     size = "small",
+    pure = "on",
     srcs = ["simple_test.go"],
 )
 

--- a/lib/tests/transitions/BUILD.bazel
+++ b/lib/tests/transitions/BUILD.bazel
@@ -105,8 +105,8 @@ go_binary(
 go_test(
     name = "test_transition_test",
     size = "small",
-    pure = "on",
     srcs = ["simple_test.go"],
+    pure = "on",
 )
 
 platform_transition_binary(


### PR DESCRIPTION
Before 3.0 final we can drop this maintenance burden