### PR TITLE
fix: propagate common attributes to generated write_file

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -75,6 +75,7 @@ bzl_library(
     name = "expand_template",
     srcs = ["expand_template.bzl"],
     deps = [
+        ":utils",
         "//lib/private:expand_template",
         "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:write_file",

--- a/lib/expand_template.bzl
+++ b/lib/expand_template.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//lib:utils.bzl", "propagate_common_rule_attributes")
 load("//lib/private:expand_template.bzl", _expand_template = "expand_template")
 
 expand_template_rule = _expand_template
@@ -17,10 +18,17 @@ def expand_template(name, template, **kwargs):
     """
     if types.is_list(template):
         write_target = "{}_tmpl".format(name)
+        write_attrs = propagate_common_rule_attributes(kwargs)
+        tags = write_attrs.pop("tags", [])
+        if "manual" not in tags:
+            tags = tags + ["manual"]
+        write_attrs["tags"] = tags
+        write_attrs["visibility"] = ["//visibility:private"]
         write_file(
             name = write_target,
             out = "{}.txt".format(write_target),
             content = template,
+            **write_attrs
         )
         template = write_target
 


### PR DESCRIPTION
When `template` is a list literal, the macro generates an inner `<name>_tmpl` write_file target but does not forward any of the common rule attributes to it. Attributes like `tags`, `visibility`, and `testonly` set on the expand_template call (or propagated to it by a wrapping macro such as tar.bzl's tar()) are therefore dropped on the generated target. The most visible symptom is `tags = ["manual"]` failing to apply, so the generated target leaks into wildcard builds.

Forward the common attributes the same way tar.bzl already does for its mtree_spec target.