### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Base Starlark libraries and basic Bazel rules which are useful for constructing rulesets and BUILD files.
 
-📚 **API documentation**: https://registry.bazel.build/docs/bazel_lib
+📚 **API documentation**: https://registry.bazel.build/modules/bazel_lib/latest/docs
 
 ## 3.0 release
 


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

Updated all occurrences of the broken `/docs/<name>` URL pattern to the new `/modules/<name>/latest/docs` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)