### PR TITLE
fix: Windows spaces in manifest paths

### DIFF
--- a/lib/tests/windows_utils/BUILD.bazel
+++ b/lib/tests/windows_utils/BUILD.bazel
@@ -1,7 +1,17 @@
 load(":exact_manifest_match_test.bzl", "windows_exact_manifest_match_test")
+load(":spaced_manifest_target_test.bzl", "windows_spaced_manifest_target_test")
 
 windows_exact_manifest_match_test(
     name = "exact_manifest_match_test",
+    size = "small",
+    target_compatible_with = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+windows_spaced_manifest_target_test(
+    name = "spaced_manifest_target_test",
     size = "small",
     target_compatible_with = select({
         "@platforms//os:windows": [],

--- a/lib/tests/windows_utils/BUILD.bazel
+++ b/lib/tests/windows_utils/BUILD.bazel
@@ -1,4 +1,5 @@
 load(":exact_manifest_match_test.bzl", "windows_exact_manifest_match_test")
+load(":sibling_payload_test.bzl", "windows_sibling_payload_test")
 load(":spaced_manifest_target_test.bzl", "windows_spaced_manifest_target_test")
 
 windows_exact_manifest_match_test(
@@ -12,6 +13,15 @@ windows_exact_manifest_match_test(
 
 windows_spaced_manifest_target_test(
     name = "spaced_manifest_target_test",
+    size = "small",
+    target_compatible_with = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+windows_sibling_payload_test(
+    name = "sibling_payload_test",
     size = "small",
     target_compatible_with = select({
         "@platforms//os:windows": [],

--- a/lib/tests/windows_utils/sibling_payload_test.bzl
+++ b/lib/tests/windows_utils/sibling_payload_test.bzl
@@ -1,0 +1,101 @@
+"Tests that the Windows launcher resolves its payload without reading the manifest."
+
+load("//lib:windows_utils.bzl", "create_windows_native_launcher_script")
+load("//lib/private:paths.bzl", "paths")
+
+_SUCCESS_MARKER = "WINDOWS_SIBLING_PAYLOAD_OK"
+
+def _windows_sibling_payload_test_impl(ctx):
+    shell_script = ctx.actions.declare_file(ctx.label.name + "_payload.sh")
+    ctx.actions.write(
+        output = shell_script,
+        content = "#!/usr/bin/env bash\necho {}\n".format(_SUCCESS_MARKER),
+        is_executable = True,
+    )
+    launcher = create_windows_native_launcher_script(ctx, shell_script)
+    launcher_rlocation = paths.to_rlocation_path(ctx, launcher)
+    shell_script_rlocation = paths.to_rlocation_path(ctx, shell_script)
+
+    test = ctx.actions.declare_file(ctx.label.name + ".bat")
+    ctx.actions.write(
+        output = test,
+        content = "\r\n".join(r"""@echo off
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION
+goto :test_main
+
+:resolve_test_runfile
+set "logical_path=%~1"
+set "resolved_path="
+if defined RUNFILES_MANIFEST_FILE if exist "!RUNFILES_MANIFEST_FILE!" (
+  set "test_manifest=!RUNFILES_MANIFEST_FILE:/=\!"
+  for /F "tokens=1,* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /l /c:"!logical_path! " "!test_manifest!"`) do (
+    set "resolved_path=%%j"
+  )
+)
+if not defined resolved_path if defined RUNFILES_DIR if exist "!RUNFILES_DIR!\!logical_path:/=\!" (
+  set "resolved_path=!RUNFILES_DIR!\!logical_path:/=\!"
+)
+if not defined resolved_path exit /b 1
+set "resolved_path=!resolved_path:/=\!"
+set "%~2=!resolved_path!"
+exit /b 0
+
+:test_main
+call :resolve_test_runfile "{launcher_rlocation}" launcher
+if errorlevel 1 exit /b 1
+call :resolve_test_runfile "{shell_script_rlocation}" payload
+if errorlevel 1 exit /b 1
+
+rem Stage the launcher next to its payload under a directory whose name contains
+rem a space, and point the manifest at a file that does not exist.  The launcher
+rem must still find its payload, proving it resolves the sibling directly rather
+rem than going through findstr -- which is what keeps it working when the
+rem manifest path exceeds MAX_PATH or the .bat is invoked via an 8.3 alias.
+set "test_root=%TEST_TMPDIR:/=\%\windows-sibling-payload"
+if exist "!test_root!" rmdir /s /q "!test_root!"
+mkdir "!test_root!"
+set "spaced_dir=!test_root!\dir with spaces"
+mkdir "!spaced_dir!"
+for %%f in ("!launcher!") do set "launcher_name=%%~nxf"
+for %%f in ("!payload!") do set "payload_name=%%~nxf"
+copy /y "!launcher!" "!spaced_dir!\!launcher_name!" >NUL
+copy /y "!payload!" "!spaced_dir!\!payload_name!" >NUL
+set "case_manifest=!test_root!\MANIFEST"
+> "!case_manifest!" echo {shell_script_rlocation} !test_root!/does-not-exist.sh
+
+set "RUNFILES_MANIFEST_FILE=!case_manifest!"
+set "RUNFILES_MANIFEST_ONLY=1"
+set "RUNFILES_DIR="
+set "case_output=%TEST_TMPDIR:/=\%\sibling-payload-output.txt"
+call "!spaced_dir!\!launcher_name!" > "!case_output!" 2>&1
+if errorlevel 1 (
+  echo>&2 FAIL: launcher exited non-zero resolving a sibling payload under a spaced path.
+  type "!case_output!" 1>&2
+  exit /b 1
+)
+%SYSTEMROOT%\system32\findstr.exe /c:"{success_marker}" "!case_output!" >NUL
+if errorlevel 1 (
+  echo>&2 FAIL: launcher did not run its sibling payload.
+  type "!case_output!" 1>&2
+  exit /b 1
+)
+exit /b 0
+""".format(
+            launcher_rlocation = launcher_rlocation,
+            shell_script_rlocation = shell_script_rlocation,
+            success_marker = _SUCCESS_MARKER,
+        ).splitlines()),
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = test,
+        runfiles = ctx.runfiles(files = [launcher, shell_script]),
+    )]
+
+windows_sibling_payload_test = rule(
+    implementation = _windows_sibling_payload_test_impl,
+    test = True,
+    toolchains = ["@bazel_tools//tools/sh:toolchain_type"],
+)

--- a/lib/tests/windows_utils/spaced_manifest_target_test.bzl
+++ b/lib/tests/windows_utils/spaced_manifest_target_test.bzl
@@ -1,0 +1,101 @@
+"Tests that runfiles manifest targets containing spaces resolve correctly."
+
+load("//lib:windows_utils.bzl", "create_windows_native_launcher_script")
+load("//lib/private:paths.bzl", "paths")
+
+_SUCCESS_MARKER = "WINDOWS_SPACED_MANIFEST_TARGET_OK"
+
+def _windows_spaced_manifest_target_test_impl(ctx):
+    shell_script = ctx.actions.declare_file(ctx.label.name + "_payload.sh")
+    ctx.actions.write(
+        output = shell_script,
+        content = "#!/usr/bin/env bash\necho {}\n".format(_SUCCESS_MARKER),
+        is_executable = True,
+    )
+    launcher = create_windows_native_launcher_script(ctx, shell_script)
+    launcher_rlocation = paths.to_rlocation_path(ctx, launcher)
+    shell_script_rlocation = paths.to_rlocation_path(ctx, shell_script)
+
+    test = ctx.actions.declare_file(ctx.label.name + ".bat")
+    ctx.actions.write(
+        output = test,
+        content = "\r\n".join(r"""@echo off
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION
+goto :test_main
+
+:resolve_test_runfile
+set "logical_path=%~1"
+set "resolved_path="
+if defined RUNFILES_MANIFEST_FILE if exist "!RUNFILES_MANIFEST_FILE!" (
+  set "test_manifest=!RUNFILES_MANIFEST_FILE:/=\!"
+  for /F "tokens=1,* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /l /c:"!logical_path! " "!test_manifest!"`) do (
+    set "resolved_path=%%j"
+  )
+)
+if not defined resolved_path if defined RUNFILES_DIR if exist "!RUNFILES_DIR!\!logical_path:/=\!" (
+  set "resolved_path=!RUNFILES_DIR!\!logical_path:/=\!"
+)
+if not defined resolved_path exit /b 1
+set "resolved_path=!resolved_path:/=\!"
+set "%~2=!resolved_path!"
+exit /b 0
+
+:test_main
+call :resolve_test_runfile "{launcher_rlocation}" launcher
+if errorlevel 1 exit /b 1
+call :resolve_test_runfile "{shell_script_rlocation}" payload
+if errorlevel 1 exit /b 1
+
+rem Stage the payload under a directory whose name contains a space, then point
+rem the manifest at it.  Bazel does not escape spaces in manifest TARGET paths:
+rem consumers are expected to split on the first space only.  A developer whose
+rem checkout lives under e.g. C:\Users\First Last hits this on every runfile.
+set "test_root=%TEST_TMPDIR:/=\%\windows-spaced-manifest-target"
+if exist "!test_root!" rmdir /s /q "!test_root!"
+mkdir "!test_root!"
+set "spaced_dir=!test_root!\dir with spaces"
+mkdir "!spaced_dir!"
+set "case_launcher=!test_root!\launcher.bat"
+set "case_payload=!spaced_dir!\payload.sh"
+set "case_manifest=!test_root!\MANIFEST"
+copy /y "!launcher!" "!case_launcher!" >NUL
+copy /y "!payload!" "!case_payload!" >NUL
+set "payload_manifest=!case_payload:\=/!"
+> "!case_manifest!" echo {shell_script_rlocation} !payload_manifest!
+
+set "RUNFILES_MANIFEST_FILE=!case_manifest!"
+set "RUNFILES_MANIFEST_ONLY=1"
+set "RUNFILES_DIR="
+set "case_output=%TEST_TMPDIR:/=\%\spaced-manifest-target-output.txt"
+call "!case_launcher!" > "!case_output!" 2>&1
+if errorlevel 1 (
+  echo>&2 FAIL: launcher exited non-zero for a manifest target containing spaces.
+  type "!case_output!" 1>&2
+  exit /b 1
+)
+%SYSTEMROOT%\system32\findstr.exe /c:"{success_marker}" "!case_output!" >NUL
+if errorlevel 1 (
+  echo>&2 FAIL: launcher did not run the payload staged under a spaced path.
+  type "!case_output!" 1>&2
+  exit /b 1
+)
+exit /b 0
+""".format(
+            launcher_rlocation = launcher_rlocation,
+            shell_script_rlocation = shell_script_rlocation,
+            success_marker = _SUCCESS_MARKER,
+        ).splitlines()),
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = test,
+        runfiles = ctx.runfiles(files = [launcher, shell_script]),
+    )]
+
+windows_spaced_manifest_target_test = rule(
+    implementation = _windows_spaced_manifest_target_test_impl,
+    test = True,
+    toolchains = ["@bazel_tools//tools/sh:toolchain_type"],
+)

--- a/lib/windows_utils.bzl
+++ b/lib/windows_utils.bzl
@@ -54,8 +54,8 @@ if not exist "%MF%" (
   exit 1
 )
 set runfile_path=%~1
-for /F "tokens=2* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /b /l /c:"!runfile_path! " "%MF%"`) do (
-  set abs_path=%%i
+for /F "tokens=1* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /b /l /c:"!runfile_path! " "%MF%"`) do (
+  set abs_path=%%j
 )
 if "!abs_path!" equ "" (
   echo>&2 ERROR: !runfile_path! not found in runfiles manifest
@@ -99,7 +99,7 @@ if defined args (
   set args=!args:\=\\\\!
   set args=!args:"=\"!
 )
-"{bash_bin}" -c "!run_script! !args!"
+"{bash_bin}" -c "'!run_script!' !args!"
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
             sh_script = paths.to_rlocation_path(ctx, shell_script),

--- a/lib/windows_utils.bzl
+++ b/lib/windows_utils.bzl
@@ -90,7 +90,9 @@ SETLOCAL ENABLEEXTENSIONS
 SETLOCAL ENABLEDELAYEDEXPANSION
 set RUNFILES_MANIFEST_ONLY=1
 {rlocation_function}
-call :rlocation "{sh_script}" run_script
+set "run_script=%~dp0{sh_basename}"
+if not exist "!run_script!" call :rlocation "{sh_script}" run_script
+set "run_script=!run_script:\=/!"
 for %%a in ("{bash_bin}") do set "bash_bin_dir=%%~dpa"
 set PATH=%bash_bin_dir%;%PATH%
 set args=%*
@@ -103,6 +105,7 @@ if defined args (
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
             sh_script = paths.to_rlocation_path(ctx, shell_script),
+            sh_basename = shell_script.basename,
             rlocation_function = BATCH_RLOCATION_FUNCTION,
         ).splitlines()),
         is_executable = True,


### PR DESCRIPTION
The batch rlocation helper parsed manifest lines with
`for /F "tokens=2*"` and kept only `%%i`, the first space-delimited word
of the target path. Bazel escapes a manifest entry only when the
RLOCATION path contains a space or a newline, marking such lines with a
leading space; in an unescaped line the first space is the separator and
everything after it is the target, spaces included. Keeping `%%i`
therefore truncated every target under a path like
C:/Users/First Last/... to C:/Users/First.

Every consumer of BATCH_RLOCATION_FUNCTION was affected. diff_test, for
example, reported

  ERROR: Cannot compare directory "_main/pkg/_gendir" and a file
         "_main/pkg/src/generated"

because the source directory resolved to a path that does not exist, so
its `if exist` check failed. Split on the first space instead.

Resolving the path correctly then exposed a second defect: the launcher
invoked `bash -c "!run_script! !args!"` unquoted, so bash word-split the
now-correct path at its spaces. Quote it.